### PR TITLE
A Variant variant of NEST that passes all tests

### DIFF
--- a/libnestutil/dictionary.cpp
+++ b/libnestutil/dictionary.cpp
@@ -251,9 +251,59 @@ equal_as_( const any_type& first, const any_type& second )
 }
 
 bool
+value_equal( const any_type& first, const any_type& second )
+{
+  // helper to provide error in case we forgot a type in the equal_as_ chain.
+  auto fail = []( const any_type& first, const any_type& second )
+  {
+    throw std::runtime_error(
+      String::compose( "Fail to compare: left '%1', right '%2'", debug_type( first ), debug_type( second ) ) );
+    return false;
+  };
+
+  // Short-circuits as soon as an equal_as_() call evaluates to true
+  // clang-format off
+  return (
+     equal_as_< long >( first, second )
+    or equal_as_< double >( first, second )
+    or equal_as_< bool >( first, second )
+    or equal_as_< std::string >( first, second )
+    or equal_as_< std::vector< long > >( first, second )
+    or equal_as_< std::vector< double > >( first, second )
+    or equal_as_< std::vector< std::string > >( first, second )
+    or equal_as_< std::vector< std::vector< double > > >( first, second )
+    or equal_as_< Dictionary >( first, second )
+    or equal_as_< std::shared_ptr< nest::Parameter > >( first, second )
+    or fail( first, second )
+  );
+  // clang-format on
+}
+
+bool
 dictionary_::operator==( const dictionary_& other ) const
 {
-  return static_cast< const maptype_& >( *this ) == static_cast< const maptype_& >( other );
+  if ( size() != other.size() )
+  {
+    return false;
+  }
+  // Iterate elements in the other Dictionary
+  for ( const auto& [ other_key, other_entry ] : other )
+  {
+    // Check if it exists in this Dictionary
+    if ( not known( other_key ) )
+    {
+      return false;
+    }
+
+    // Check for equality
+    const auto& this_entry = maptype_::at( other_key );
+    if ( not value_equal( this_entry.item, other_entry.item ) )
+    {
+      return false;
+    }
+  }
+  // All elements are equal
+  return true;
 }
 
 void

--- a/libnestutil/dictionary.cpp
+++ b/libnestutil/dictionary.cpp
@@ -127,6 +127,31 @@ dictionary_::cast_value_< std::vector< double > >( const any_type& value, const 
 }
 
 
+template <>
+std::vector< std::string >
+dictionary_::cast_value_< std::vector< std::string > >( const any_type& value, const std::string& key ) const
+{
+  if ( std::holds_alternative< EmptyList >( value ) )
+  {
+    return std::vector< std::string >();
+  }
+
+  try
+  {
+    if ( const std::vector< std::string >* v = std::get_if< std::vector< std::string > >( &value ) )
+    {
+      return *v;
+    }
+    throw std::bad_variant_access(); // deflect to error handling below
+  }
+  catch ( const std::bad_variant_access& )
+  {
+    const std::string msg =
+      String::compose( "Failed to cast '%1' from %2 to type std::vector<double>", key, debug_type( value ) );
+    throw nest::TypeMismatch( msg );
+  }
+}
+
 std::string
 debug_type( const any_type& operand )
 {

--- a/libnestutil/dictionary.cpp
+++ b/libnestutil/dictionary.cpp
@@ -239,6 +239,26 @@ operator<<( std::ostream& os, const Dictionary& dict )
   return os << "}";
 }
 
+std::ostream&
+operator<<( std::ostream& os, const std::monostate& )
+{
+  os << "None";
+  return os;
+}
+
+std::ostream&
+operator<<( std::ostream& os, const AnyVector& av )
+{
+  os << "[";
+  for ( auto v : av )
+  {
+    std::visit( []( const auto& arg ) { std::cout << arg << " "; }, v );
+  }
+  os << "\b]";
+  return os;
+}
+
+
 /**
  * Return true only if first and second both hold type T and compare equal as T.
  */

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -39,7 +39,7 @@
 
 class dictionary_;
 class Dictionary;
-
+class AnyVector;
 namespace nest
 {
 class Parameter;
@@ -62,7 +62,8 @@ template < typename... Scalars >
 struct DictionarySchemaBuilder
 {
   template < typename... Extras >
-  using VariantType = std::variant< Scalars...,              // scalar types
+  using VariantType = std::variant< std::monostate,
+    Scalars...,                                              // scalar types
     std::vector< Scalars >...,                               // vector variants of the scalar types
     std::vector< std::vector< Scalars > >...,                // vector-vector variants of the scalar types
     std::vector< std::vector< std::vector< Scalars > > >..., // vector-vector variants of the scalar types
@@ -78,7 +79,18 @@ using any_type = DictionarySchema::VariantType< std::shared_ptr< nest::NodeColle
   std::vector< std::shared_ptr< nest::NodeCollection > >,
   std::shared_ptr< nest::Parameter >,
   nest::VerbosityLevel,
+  AnyVector,
   EmptyList >;
+
+class AnyVector : public std::vector< any_type >
+{
+  using vectype_ = std::vector< any_type >;
+  using vectype_::vectype_; // Inherit constructors
+};
+
+std::ostream& operator<<( std::ostream& os, const std::monostate& );
+
+std::ostream& operator<<( std::ostream& os, const AnyVector& av );
 
 
 // Define a simple Concept for "Integer Integers" (excluding bool and char)

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -115,6 +115,17 @@ public:
   any_type& at( const std::string& key );
   const any_type& at( const std::string& key ) const;
 
+  /**
+   * @brief Check whether the dictionary is equal to another dictionary.
+   *
+   * Two dictionaries are equal only if they contain the exact same entries with the same values.
+   *
+   * @param other dictionary to check against.
+   * @return true if the dictionary is equal to the other dictionary, false if not.
+   */
+  bool operator==( const Dictionary& other ) const;
+
+
   auto begin() const;
   auto end() const;
 
@@ -486,6 +497,12 @@ std::vector< double > dictionary_::cast_value_< std::vector< double > >( const a
 template <>
 std::vector< std::string > dictionary_::cast_value_< std::vector< std::string > >( const any_type& value,
   const std::string& key ) const;
+
+inline bool
+Dictionary::operator==( const Dictionary& other ) const
+{
+  return **this == *other;
+}
 
 inline auto
 Dictionary::size() const

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -61,28 +61,24 @@ struct EmptyList
 template < typename... Scalars >
 struct DictionarySchemaBuilder
 {
-  template < typename T >
-  static constexpr bool is_defined_scalar = ( std::is_same_v< T, Scalars > or ... );
-  ;
-
   template < typename... Extras >
-  using VariantType = std::variant< Scalars..., // scalar types
-    std::vector< Scalars >...,                  // vector variants of the scalar types
-    Extras...                                   // any extra types
+  using VariantType = std::variant< Scalars...,              // scalar types
+    std::vector< Scalars >...,                               // vector variants of the scalar types
+    std::vector< std::vector< Scalars > >...,                // vector-vector variants of the scalar types
+    std::vector< std::vector< std::vector< Scalars > > >..., // vector-vector variants of the scalar types
+    std::vector< std::vector< std::vector< std::vector< Scalars > > > >..., // vector-vector variants of the scalar
+                                                                            // types
+    Extras...                                                               // any extra types
     >;
 };
 
-using DictionarySchema = DictionarySchemaBuilder< int, long, double, bool, std::string, Dictionary >;
+using DictionarySchema = DictionarySchemaBuilder< long, double, bool, std::string, Dictionary >;
 
 using any_type = DictionarySchema::VariantType< std::shared_ptr< nest::NodeCollection >,
+  std::vector< std::shared_ptr< nest::NodeCollection > >,
   std::shared_ptr< nest::Parameter >,
   nest::VerbosityLevel,
-  EmptyList,
-  // std::vector< std::string >,
-  std::vector< std::vector< long > >,
-  std::vector< std::vector< double > >,
-  std::vector< std::vector< std::vector< long > > >,
-  std::vector< std::vector< std::vector< double > > > >;
+  EmptyList >;
 
 
 // Define a simple Concept for "Integer Integers" (excluding bool and char)
@@ -99,6 +95,7 @@ is_type( const any_type& operand )
 {
   return std::holds_alternative< T >( operand );
 }
+
 
 class Dictionary : public std::shared_ptr< dictionary_ >
 {
@@ -455,13 +452,9 @@ public:
 
 std::ostream& operator<<( std::ostream& os, const dictionary_& dict );
 
-template <>
-double dictionary_::cast_value_< double >( const any_type& value, const std::string& key ) const;
-
 //! Specialization that allows passing long where double is expected
 template <>
-std::vector< double > dictionary_::cast_value_< std::vector< double > >( const any_type& value,
-  const std::string& key ) const;
+double dictionary_::cast_value_< double >( const any_type& value, const std::string& key ) const;
 
 inline auto
 Dictionary::begin() const
@@ -478,11 +471,20 @@ Dictionary::end() const
 /**
  * Specialization that allows passing long vectors where double vectors are expected.
  *
+ * Also handles empty vectors.
+ *
  * @note This specialization forwards to cast_vector_value_<double>, but is required explicitly,
  *       because, e.g., get(), calls cast_value_() directly even if the argument is a vector.
  */
 template <>
 std::vector< double > dictionary_::cast_value_< std::vector< double > >( const any_type& value,
+  const std::string& key ) const;
+
+/**
+ * Specialization that allows passing empty lists.
+ */
+template <>
+std::vector< std::string > dictionary_::cast_value_< std::vector< std::string > >( const any_type& value,
   const std::string& key ) const;
 
 inline auto

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -58,18 +58,20 @@ struct EmptyList
   bool operator==( const EmptyList& ) const = default;
 };
 
+// TODO PyNEST-NG: check if we need all scalars in all nested vector levels, keeping the variant smaller may
+// improve performance.
 template < typename... Scalars >
 struct DictionarySchemaBuilder
 {
   template < typename... Extras >
-  using VariantType = std::variant< std::monostate,
+  using VariantType = std::variant< std::monostate,          // default-initialized any_type value, representing missing
+                                                             // non-local nodes in a node-colection
     Scalars...,                                              // scalar types
     std::vector< Scalars >...,                               // vector variants of the scalar types
-    std::vector< std::vector< Scalars > >...,                // vector-vector variants of the scalar types
-    std::vector< std::vector< std::vector< Scalars > > >..., // vector-vector variants of the scalar types
-    std::vector< std::vector< std::vector< std::vector< Scalars > > > >..., // vector-vector variants of the scalar
-                                                                            // types
-    Extras...                                                               // any extra types
+    std::vector< std::vector< Scalars > >...,                // vec-vec variants of the scalar types
+    std::vector< std::vector< std::vector< Scalars > > >..., // vec-vec-vec variants of the scalar types (for
+                                                             // correlomatrix-detector)
+    Extras...                                                // any extra types (see definition of any_type below)
     >;
 };
 
@@ -79,7 +81,7 @@ using any_type = DictionarySchema::VariantType< std::shared_ptr< nest::NodeColle
   std::vector< std::shared_ptr< nest::NodeCollection > >,
   std::shared_ptr< nest::Parameter >,
   nest::VerbosityLevel,
-  AnyVector,
+  AnyVector, // this is only used to hold status data from elements of a node collection in a NEST 3.9 compatible way
   EmptyList >;
 
 class AnyVector : public std::vector< any_type >

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -72,13 +72,13 @@ struct DictionarySchemaBuilder
     >;
 };
 
-using DictionarySchema =
-  DictionarySchemaBuilder< size_t, long, int, unsigned int, double, bool, std::string, Dictionary >;
+using DictionarySchema = DictionarySchemaBuilder< int, long, double, bool, std::string, Dictionary >;
 
 using any_type = DictionarySchema::VariantType< std::shared_ptr< nest::NodeCollection >,
   std::shared_ptr< nest::Parameter >,
   nest::VerbosityLevel,
   EmptyList,
+  // std::vector< std::string >,
   std::vector< std::vector< long > >,
   std::vector< std::vector< double > >,
   std::vector< std::vector< std::vector< long > > >,

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -189,7 +189,7 @@ aeif_cond_alpha_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::g_L ] = g_L;
   d[ names::E_L ] = E_L;
   d[ names::V_reset ] = V_reset_;
-  d[ names::n_receptors ] = n_receptors();
+  d[ names::n_receptors ] = std::vector< long >( n_receptors() );
   d[ names::E_rev ] = E_rev;
   d[ names::tau_syn ] = tau_syn;
   d[ names::a ] = a;

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -189,7 +189,7 @@ aeif_cond_alpha_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::g_L ] = g_L;
   d[ names::E_L ] = E_L;
   d[ names::V_reset ] = V_reset_;
-  d[ names::n_receptors ] = std::vector< long >( n_receptors() );
+  d[ names::n_receptors ] = static_cast< long >( n_receptors() );
   d[ names::E_rev ] = E_rev;
   d[ names::tau_syn ] = tau_syn;
   d[ names::a ] = a;

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -189,7 +189,7 @@ aeif_cond_beta_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::g_L ] = g_L;
   d[ names::E_L ] = E_L;
   d[ names::V_reset ] = V_reset_;
-  d[ names::n_receptors ] = n_receptors();
+  d[ names::n_receptors ] = std::vector< long >( n_receptors() );
   d[ names::E_rev ] = E_rev;
   d[ names::tau_rise ] = tau_rise;
   d[ names::tau_decay ] = tau_decay;

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -189,7 +189,7 @@ aeif_cond_beta_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::g_L ] = g_L;
   d[ names::E_L ] = E_L;
   d[ names::V_reset ] = V_reset_;
-  d[ names::n_receptors ] = std::vector< long >( n_receptors() );
+  d[ names::n_receptors ] = static_cast< long >( n_receptors() );
   d[ names::E_rev ] = E_rev;
   d[ names::tau_rise ] = tau_rise;
   d[ names::tau_decay ] = tau_decay;

--- a/models/bernoulli_synapse.h
+++ b/models/bernoulli_synapse.h
@@ -200,7 +200,7 @@ bernoulli_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
   d[ names::p_transmit ] = p_transmit_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/clopath_synapse.h
+++ b/models/clopath_synapse.h
@@ -305,7 +305,7 @@ clopath_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::tau_x ] = tau_x_;
   d[ names::Wmin ] = Wmin_;
   d[ names::Wmax ] = Wmax_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/cont_delay_synapse_impl.h
+++ b/models/cont_delay_synapse_impl.h
@@ -50,7 +50,7 @@ cont_delay_synapse< targetidentifierT >::get_status( Dictionary& d ) const
 
   d[ names::weight ] = weight_;
   d[ names::delay ] = Time( Time::step( get_delay_steps() ) ).get_ms() - delay_offset_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -115,7 +115,7 @@ nest::correlomatrix_detector::Parameters_::get( Dictionary& d ) const
   d[ names::tau_max ] = tau_max_.get_ms();
   d[ names::Tstart ] = Tstart_.get_ms();
   d[ names::Tstop ] = Tstop_.get_ms();
-  d[ names::N_channels ] = std::vector< long >( N_channels_ );
+  d[ names::N_channels ] = static_cast< long >( N_channels_ );
 }
 
 void

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -115,7 +115,7 @@ nest::correlomatrix_detector::Parameters_::get( Dictionary& d ) const
   d[ names::tau_max ] = tau_max_.get_ms();
   d[ names::Tstart ] = Tstart_.get_ms();
   d[ names::Tstop ] = Tstop_.get_ms();
-  d[ names::N_channels ] = N_channels_;
+  d[ names::N_channels ] = std::vector< long >( N_channels_ );
 }
 
 void

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -115,7 +115,7 @@ nest::correlospinmatrix_detector::Parameters_::get( Dictionary& d ) const
   d[ names::tau_max ] = tau_max_.get_ms();
   d[ names::Tstart ] = Tstart_.get_ms();
   d[ names::Tstop ] = Tstop_.get_ms();
-  d[ names::N_channels ] = std::vector< long >( N_channels_ );
+  d[ names::N_channels ] = static_cast< long >( N_channels_ );
 }
 
 void

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -115,7 +115,7 @@ nest::correlospinmatrix_detector::Parameters_::get( Dictionary& d ) const
   d[ names::tau_max ] = tau_max_.get_ms();
   d[ names::Tstart ] = Tstart_.get_ms();
   d[ names::Tstop ] = Tstop_.get_ms();
-  d[ names::N_channels ] = N_channels_;
+  d[ names::N_channels ] = std::vector< long >( N_channels_ );
 }
 
 void

--- a/models/diffusion_connection.h
+++ b/models/diffusion_connection.h
@@ -187,7 +187,7 @@ diffusion_connection< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::weight ] = weight_;
   d[ names::drift_factor ] = drift_factor_;
   d[ names::diffusion_factor ] = diffusion_factor_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/eprop_learning_signal_connection.h
+++ b/models/eprop_learning_signal_connection.h
@@ -208,7 +208,7 @@ eprop_learning_signal_connection< targetidentifierT >::get_status( Dictionary& d
 {
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/eprop_learning_signal_connection_bsshslm_2020.h
+++ b/models/eprop_learning_signal_connection_bsshslm_2020.h
@@ -211,7 +211,7 @@ eprop_learning_signal_connection_bsshslm_2020< targetidentifierT >::get_status( 
 {
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/eprop_synapse.h
+++ b/models/eprop_synapse.h
@@ -519,7 +519,7 @@ eprop_synapse< targetidentifierT >::get_status( Dictionary& d ) const
 {
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 
   Dictionary optimizer_dict;
 

--- a/models/eprop_synapse_bsshslm_2020.h
+++ b/models/eprop_synapse_bsshslm_2020.h
@@ -581,7 +581,7 @@ eprop_synapse_bsshslm_2020< targetidentifierT >::get_status( Dictionary& d ) con
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
   d[ names::tau_m_readout ] = tau_m_readout_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 
   Dictionary optimizer_dict;
 

--- a/models/gap_junction.h
+++ b/models/gap_junction.h
@@ -173,7 +173,7 @@ gap_junction< targetidentifierT >::get_status( Dictionary& d ) const
   // this function in SLI/pyNEST
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -160,7 +160,7 @@ nest::gif_cond_exp_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::V_T_star ] = V_T_star_;
   d[ names::lambda_0 ] = lambda_0_ * 1000.0; // convert to 1/s
   d[ names::t_ref ] = t_ref_;
-  d[ names::n_receptors ] = std::vector< long >( n_receptors() );
+  d[ names::n_receptors ] = static_cast< long >( n_receptors() );
   d[ names::E_rev ] = E_rev_;
   d[ names::has_connections ] = has_connections_;
   d[ names::gsl_error_tol ] = gsl_error_tol;

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -160,7 +160,7 @@ nest::gif_cond_exp_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::V_T_star ] = V_T_star_;
   d[ names::lambda_0 ] = lambda_0_ * 1000.0; // convert to 1/s
   d[ names::t_ref ] = t_ref_;
-  d[ names::n_receptors ] = n_receptors();
+  d[ names::n_receptors ] = std::vector< long >( n_receptors() );
   d[ names::E_rev ] = E_rev_;
   d[ names::has_connections ] = has_connections_;
   d[ names::gsl_error_tol ] = gsl_error_tol;

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -114,7 +114,7 @@ nest::gif_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::lambda_0 ] = lambda_0_ * 1000.0; // convert to 1/s
   d[ names::t_ref ] = t_ref_;
 
-  d[ names::n_receptors ] = n_receptors_();
+  d[ names::n_receptors ] = std::vector< long >( n_receptors_() );
   d[ names::has_connections ] = has_connections_;
 
   d[ names::tau_syn ] = tau_syn_;

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -114,7 +114,7 @@ nest::gif_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::lambda_0 ] = lambda_0_ * 1000.0; // convert to 1/s
   d[ names::t_ref ] = t_ref_;
 
-  d[ names::n_receptors ] = std::vector< long >( n_receptors_() );
+  d[ names::n_receptors ] = static_cast< long >( n_receptors_() );
   d[ names::has_connections ] = has_connections_;
 
   d[ names::tau_syn ] = tau_syn_;

--- a/models/ht_synapse.h
+++ b/models/ht_synapse.h
@@ -245,7 +245,7 @@ ht_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::tau_P ] = tau_P_;
   d[ names::delta_P ] = delta_P_;
   d[ names::P ] = p_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -127,7 +127,7 @@ iaf_psc_alpha_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::tau_m ] = Tau_;
   d[ names::t_ref ] = refractory_time_;
   d[ names::V_min ] = LowerBound_ + E_L_;
-  d[ names::n_synapses ] = n_receptors_();
+  d[ names::n_synapses ] = std::vector< long >( n_receptors_() );
   d[ names::has_connections ] = has_connections_;
   d[ names::tau_syn ] = tau_syn_;
 }

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -127,7 +127,7 @@ iaf_psc_alpha_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::tau_m ] = Tau_;
   d[ names::t_ref ] = refractory_time_;
   d[ names::V_min ] = LowerBound_ + E_L_;
-  d[ names::n_synapses ] = std::vector< long >( n_receptors_() );
+  d[ names::n_synapses ] = static_cast< long >( n_receptors_() );
   d[ names::has_connections ] = has_connections_;
   d[ names::tau_syn ] = tau_syn_;
 }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -122,7 +122,7 @@ iaf_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::C_m ] = C_;
   d[ names::tau_m ] = Tau_;
   d[ names::t_ref ] = refractory_time_;
-  d[ names::n_synapses ] = n_receptors_();
+  d[ names::n_synapses ] = std::vector< long >( n_receptors_() );
   d[ names::has_connections ] = has_connections_;
   d[ names::tau_syn ] = tau_syn_;
 }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -122,7 +122,7 @@ iaf_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
   d[ names::C_m ] = C_;
   d[ names::tau_m ] = Tau_;
   d[ names::t_ref ] = refractory_time_;
-  d[ names::n_synapses ] = std::vector< long >( n_receptors_() );
+  d[ names::n_synapses ] = static_cast< long >( n_receptors_() );
   d[ names::has_connections ] = has_connections_;
   d[ names::tau_syn ] = tau_syn_;
 }

--- a/models/jonke_synapse.h
+++ b/models/jonke_synapse.h
@@ -364,7 +364,7 @@ jonke_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
   d[ names::Kplus ] = Kplus_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -164,7 +164,7 @@ void
 nest::music_cont_out_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
-  d[ names::port_width ] = static_cast<long>(port_width_);
+  d[ names::port_width ] = static_cast< long >( port_width_ );
 }
 
 /* ----------------------------------------------------------------

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -164,7 +164,7 @@ void
 nest::music_cont_out_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
-  d[ names::port_width ] = port_width_;
+  d[ names::port_width ] = static_cast<long>(port_width_);
 }
 
 /* ----------------------------------------------------------------

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -180,7 +180,7 @@ nest::music_event_out_proxy::get_status( Dictionary& d ) const
   P_.get( d );
   S_.get( d );
 
-  d[ names::connection_count ] = V_.index_map_.size();
+  d[ names::connection_count ] = static_cast<long>(V_.index_map_.size());
 
   // make a copy, since MUSIC uses int instead of long int
   std::vector< long > pInd_map_long( V_.index_map_.size() );

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -180,7 +180,7 @@ nest::music_event_out_proxy::get_status( Dictionary& d ) const
   P_.get( d );
   S_.get( d );
 
-  d[ names::connection_count ] = static_cast<long>(V_.index_map_.size());
+  d[ names::connection_count ] = static_cast< long >( V_.index_map_.size() );
 
   // make a copy, since MUSIC uses int instead of long int
   std::vector< long > pInd_map_long( V_.index_map_.size() );

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -121,7 +121,7 @@ public:
     Dictionary dict;
     dict[ names::messages ] = messages;
     dict[ names::message_times ] = std::vector< double >( message_times );
-    d[ names::n_messages ] = static_cast<long>(messages.size());
+    d[ names::n_messages ] = static_cast< long >( messages.size() );
     d[ names::data ] = dict;
   }
 

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -121,7 +121,7 @@ public:
     Dictionary dict;
     dict[ names::messages ] = messages;
     dict[ names::message_times ] = std::vector< double >( message_times );
-    d[ names::n_messages ] = messages.size();
+    d[ names::n_messages ] = static_cast<long>(messages.size());
     d[ names::data ] = dict;
   }
 

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -196,7 +196,7 @@ nest::music_rate_out_proxy::get_status( Dictionary& d ) const
   P_.get( d );
   S_.get( d );
 
-  d[ names::connection_count ] = static_cast<long>(V_.index_map_.size());
+  d[ names::connection_count ] = static_cast< long >( V_.index_map_.size() );
 
   // make a copy, since MUSIC uses int instead of long int
   std::vector< long > pInd_map_long( V_.index_map_.size() );

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -196,7 +196,7 @@ nest::music_rate_out_proxy::get_status( Dictionary& d ) const
   P_.get( d );
   S_.get( d );
 
-  d[ names::connection_count ] = V_.index_map_.size();
+  d[ names::connection_count ] = static_cast<long>(V_.index_map_.size());
 
   // make a copy, since MUSIC uses int instead of long int
   std::vector< long > pInd_map_long( V_.index_map_.size() );

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -124,7 +124,7 @@ nest::ppd_sup_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
   d[ names::dead_time ] = dead_time_;
-  d[ names::n_proc ] = n_proc_;
+  d[ names::n_proc ] = std::vector< long >( n_proc_ );
   d[ names::frequency ] = frequency_;
   d[ names::relative_amplitude ] = amplitude_;
 }

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -124,7 +124,7 @@ nest::ppd_sup_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
   d[ names::dead_time ] = dead_time_;
-  d[ names::n_proc ] = std::vector< long >( n_proc_ );
+  d[ names::n_proc ] = static_cast< long >( n_proc_ );
   d[ names::frequency ] = frequency_;
   d[ names::relative_amplitude ] = amplitude_;
 }

--- a/models/rate_connection_delayed.h
+++ b/models/rate_connection_delayed.h
@@ -162,7 +162,7 @@ rate_connection_delayed< targetidentifierT >::get_status( Dictionary& d ) const
 {
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/rate_connection_instantaneous.h
+++ b/models/rate_connection_instantaneous.h
@@ -167,7 +167,7 @@ rate_connection_instantaneous< targetidentifierT >::get_status( Dictionary& d ) 
 {
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/sic_connection.h
+++ b/models/sic_connection.h
@@ -150,7 +150,7 @@ sic_connection< targetidentifierT >::get_status( Dictionary& d ) const
   // this function in SLI/pyNEST
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/static_synapse.h
+++ b/models/static_synapse.h
@@ -189,7 +189,7 @@ static_synapse< targetidentifierT >::get_status( Dictionary& d ) const
 
   ConnectionBase::get_status( d );
   d[ names::weight ] = weight_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/static_synapse_hom_w.h
+++ b/models/static_synapse_hom_w.h
@@ -196,7 +196,7 @@ void
 static_synapse_hom_w< targetidentifierT >::get_status( Dictionary& d ) const
 {
   ConnectionBase::get_status( d );
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 } // namespace

--- a/models/stdp_nn_pre_centered_synapse.h
+++ b/models/stdp_nn_pre_centered_synapse.h
@@ -345,7 +345,7 @@ stdp_nn_pre_centered_synapse< targetidentifierT >::get_status( Dictionary& d ) c
   d[ names::mu_minus ] = mu_minus_;
   d[ names::Wmax ] = Wmax_;
   d[ names::Kplus ] = Kplus_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_nn_restr_synapse.h
+++ b/models/stdp_nn_restr_synapse.h
@@ -336,7 +336,7 @@ stdp_nn_restr_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::mu_plus ] = mu_plus_;
   d[ names::mu_minus ] = mu_minus_;
   d[ names::Wmax ] = Wmax_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_nn_symm_synapse.h
+++ b/models/stdp_nn_symm_synapse.h
@@ -326,7 +326,7 @@ stdp_nn_symm_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::mu_plus ] = mu_plus_;
   d[ names::mu_minus ] = mu_minus_;
   d[ names::Wmax ] = Wmax_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_pl_synapse_hom.h
+++ b/models/stdp_pl_synapse_hom.h
@@ -321,7 +321,7 @@ stdp_pl_synapse_hom< targetidentifierT >::get_status( Dictionary& d ) const
 
   // own properties, different for individual synapse
   d[ names::Kplus ] = Kplus_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_synapse.h
+++ b/models/stdp_synapse.h
@@ -316,7 +316,7 @@ stdp_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::mu_minus ] = mu_minus_;
   d[ names::Wmax ] = Wmax_;
   d[ names::Kplus ] = Kplus_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_synapse_hom.h
+++ b/models/stdp_synapse_hom.h
@@ -347,7 +347,7 @@ stdp_synapse_hom< targetidentifierT >::get_status( Dictionary& d ) const
 
   // own properties, different for individual synapse
   d[ names::Kplus ] = Kplus_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/tsodyks2_synapse.h
+++ b/models/tsodyks2_synapse.h
@@ -285,7 +285,7 @@ tsodyks2_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::tau_rec ] = tau_rec_;
   d[ names::tau_fac ] = tau_fac_;
   d[ names::x ] = x_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/tsodyks_synapse.h
+++ b/models/tsodyks_synapse.h
@@ -320,7 +320,7 @@ tsodyks_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::x ] = x_;
   d[ names::y ] = y_;
   d[ names::u ] = u_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/urbanczik_synapse.h
+++ b/models/urbanczik_synapse.h
@@ -309,7 +309,7 @@ urbanczik_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::eta ] = eta_;
   d[ names::Wmin ] = Wmin_;
   d[ names::Wmax ] = Wmax_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/vogels_sprekeler_synapse.h
+++ b/models/vogels_sprekeler_synapse.h
@@ -293,7 +293,7 @@ vogels_sprekeler_synapse< targetidentifierT >::get_status( Dictionary& d ) const
   d[ names::eta ] = eta_;
   d[ names::Wmax ] = Wmax_;
   d[ names::Kplus ] = Kplus_;
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/weight_optimizer.cpp
+++ b/models/weight_optimizer.cpp
@@ -54,7 +54,7 @@ void
 WeightOptimizerCommonProperties::get_status( Dictionary& d ) const
 {
   d[ names::optimizer ] = get_name();
-  d[ names::batch_size ] = batch_size_;
+  d[ names::batch_size ] = std::vector< long >( batch_size_ );
   d[ names::eta ] = eta_;
   d[ names::Wmin ] = Wmin_;
   d[ names::Wmax ] = Wmax_;

--- a/models/weight_optimizer.cpp
+++ b/models/weight_optimizer.cpp
@@ -54,7 +54,7 @@ void
 WeightOptimizerCommonProperties::get_status( Dictionary& d ) const
 {
   d[ names::optimizer ] = get_name();
-  d[ names::batch_size ] = std::vector< long >( batch_size_ );
+  d[ names::batch_size ] = static_cast< long >( batch_size_ );
   d[ names::eta ] = eta_;
   d[ names::Wmin ] = Wmin_;
   d[ names::Wmax ] = Wmax_;

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -224,7 +224,7 @@ nest::ArchivingNode::get_status( Dictionary& d ) const
   d[ names::tau_minus_triplet ] = tau_minus_triplet_;
   d[ names::post_trace ] = trace_;
 #ifdef DEBUG_ARCHIVER
-  d[ names::archiver_length ] = history_.size();
+  d[ names::archiver_length ] = static_cast< long >( history_.size() );
 #endif
 
   // add status dict items from the parent class

--- a/nestkernel/buffer_resize_log.cpp
+++ b/nestkernel/buffer_resize_log.cpp
@@ -58,13 +58,13 @@ BufferResizeLog::add_entry( size_t global_max_spikes_sent, size_t new_buffer_siz
 void
 BufferResizeLog::to_dict( Dictionary& events ) const
 {
-  auto& times = events.get_vector< int >( names::times );
+  auto& times = events.get_vector< long >( names::times );
   times.insert( times.end(), time_steps_.begin(), time_steps_.end() );
 
-  auto& gmss = events.get_vector< int >( names::global_max_spikes_sent );
+  auto& gmss = events.get_vector< long >( names::global_max_spikes_sent );
   gmss.insert( gmss.end(), global_max_spikes_sent_.begin(), global_max_spikes_sent_.end() );
 
-  auto& nbs = events.get_vector< int >( names::new_buffer_size );
+  auto& nbs = events.get_vector< long >( names::new_buffer_size );
   nbs.insert( nbs.end(), new_buffer_size_.begin(), new_buffer_size_.end() );
 }
 

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -100,8 +100,8 @@ ConnectionGeneratorBuilder::connect_()
       throw BadProperty( "The parameter map has to contain the indices of weight and delay." );
     }
 
-    const size_t d_idx = params_map_.get< size_t >( names::delay );
-    const size_t w_idx = params_map_.get< size_t >( names::weight );
+    const size_t d_idx = params_map_.get< long >( names::delay );
+    const size_t w_idx = params_map_.get< long >( names::weight );
 
     const bool d_idx_is_0_or_1 = d_idx == 0 or ( d_idx == 1 );
     const bool w_idx_is_0_or_1 = w_idx == 0 or ( w_idx == 1 );

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -100,6 +100,8 @@ ConnectionGeneratorBuilder::connect_()
       throw BadProperty( "The parameter map has to contain the indices of weight and delay." );
     }
 
+    // Getting long here into size_t does not need protection, because we only permit 0 and 1 as values
+    // and check this right below.
     const size_t d_idx = params_map_.get< long >( names::delay );
     const size_t w_idx = params_map_.get< long >( names::weight );
 

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -90,7 +90,7 @@ ConnectionLabel< ConnectionT >::get_status( Dictionary& d ) const
   // override names::size_of from ConnectionT,
   // as the size from ConnectionLabel< ConnectionT > is
   // one long larger
-  d[ names::size_of ] = sizeof( *this );
+  d[ names::size_of ] = static_cast< long >( sizeof( *this ) );
 }
 
 template < typename ConnectionT >

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -602,12 +602,12 @@ nest::ConnectionManager::connect( const size_t snode_id,
 }
 
 void
-nest::ConnectionManager::connect_arrays( long* sources,
-  long* targets,
-  double* weights,
-  double* delays,
+nest::ConnectionManager::connect_arrays( const long* sources,
+  const long* targets,
+  const double* weights,
+  const double* delays,
   const std::vector< std::string >& p_keys,
-  double* p_values,
+  const double* p_values,
   size_t n,
   const std::string& syn_model )
 {
@@ -617,7 +617,7 @@ nest::ConnectionManager::connect_arrays( long* sources,
 
   // Mapping pointers to the first parameter value of each parameter to their respective names.
   // The bool indicates whether the value is an integer or not, and is determined at a later point.
-  std::map< std::string, std::pair< double*, bool > > param_pointers;
+  std::map< std::string, std::pair< const double*, bool > > param_pointers;
   if ( p_keys.size() != 0 )
   {
     size_t i = 0;

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -217,7 +217,7 @@ nest::ConnectionManager::get_status( Dictionary& dict )
   dict[ names::max_delay ] = Time( Time::step( max_delay_ ) ).get_ms();
 
   const size_t n = get_num_connections();
-  dict[ names::num_connections ] = n;
+  dict[ names::num_connections ] = static_cast< long >( n );
   dict[ names::keep_source_table ] = keep_source_table_;
   dict[ names::use_compressed_spikes ] = use_compressed_spikes_;
 
@@ -241,11 +241,11 @@ nest::ConnectionManager::get_synapse_status( const size_t source_node_id,
   kernel().model_manager.assert_valid_syn_id( syn_id, kernel().vp_manager.get_thread_id() );
 
   Dictionary dict;
-  dict[ names::source ] = source_node_id;
+  dict[ names::source ] = static_cast< long >( source_node_id );
   dict[ names::synapse_model ] = kernel().model_manager.get_connection_model( syn_id, /* thread */ 0 ).get_name();
-  dict[ names::target_thread ] = tid;
-  dict[ names::synapse_id ] = syn_id;
-  dict[ names::port ] = lcid;
+  dict[ names::target_thread ] = static_cast< long >( tid );
+  dict[ names::synapse_id ] = static_cast< long >( syn_id );
+  dict[ names::port ] = static_cast< long >( lcid );
 
   const Node* source = kernel().node_manager.get_node_or_proxy( source_node_id, tid );
   const Node* target = kernel().node_manager.get_node_or_proxy( target_node_id, tid );
@@ -392,7 +392,7 @@ nest::ConnectionManager::get_conn_builder( const std::string& name,
     throw IllegalConnection( String::compose( "Unknown connection rule '%1'.", name ) );
   }
 
-  const size_t rule_id = connruledict_.get< size_t >( name );
+  const size_t rule_id = connruledict_.get< long >( name );
   BipartiteConnBuilder* cb =
     connbuilder_factories_.at( rule_id )->create( sources, targets, third_out, conn_spec, syn_specs );
   assert( cb );
@@ -412,7 +412,7 @@ nest::ConnectionManager::get_third_conn_builder( const std::string& name,
     throw IllegalConnection( String::compose( "Unknown third-factor connection rule '%1'.", name ) );
   }
 
-  const size_t rule_id = thirdconnruledict_.get< size_t >( name );
+  const size_t rule_id = thirdconnruledict_.get< long >( name );
   ThirdOutBuilder* cb =
     thirdconnbuilder_factories_.at( rule_id )->create( sources, targets, third_in, conn_spec, syn_specs );
   assert( cb );

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -250,8 +250,7 @@ nest::ConnectionManager::get_synapse_status( const size_t source_node_id,
   const Node* source = kernel().node_manager.get_node_or_proxy( source_node_id, tid );
   const Node* target = kernel().node_manager.get_node_or_proxy( target_node_id, tid );
 
-  // synapses from neurons to neurons and from neurons to globally
-  // receiving devices
+  // synapses from neurons to neurons and from neurons to globally receiving devices
   if ( ( source->has_proxies() and target->has_proxies() and connections_[ tid ][ syn_id ] )
     or ( ( source->has_proxies() and not target->has_proxies() and not target->local_receiver()
       and connections_[ tid ][ syn_id ] ) ) )

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -164,12 +164,12 @@ public:
    */
   bool connect( const size_t snode_id, const size_t target, const Dictionary& params, const synindex syn_id );
 
-  void connect_arrays( long* sources,
-    long* targets,
-    double* weights,
-    double* delays,
+  void connect_arrays( const long* sources,
+    const long* targets,
+    const double* weights,
+    const double* delays,
     const std::vector< std::string >& p_keys,
-    double* p_values,
+    const double* p_values,
     size_t n,
     const std::string& syn_model );
 

--- a/nestkernel/connection_manager_impl.h
+++ b/nestkernel/connection_manager_impl.h
@@ -48,7 +48,7 @@ ConnectionManager::register_conn_builder( const std::string& name )
 
   const size_t idx = connbuilder_factories_.size();
   connbuilder_factories_.push_back( cb );
-  connruledict_[ name ] = idx;
+  connruledict_[ name ] = static_cast< long >( idx );
 }
 
 template < typename ThirdConnBuilder >
@@ -60,7 +60,7 @@ ConnectionManager::register_third_conn_builder( const std::string& name )
   assert( cb );
   const size_t idx = thirdconnbuilder_factories_.size();
   thirdconnbuilder_factories_.push_back( cb );
-  thirdconnruledict_[ name ] = idx;
+  thirdconnruledict_[ name ] = static_cast< long >( idx );
 }
 
 inline void

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -255,7 +255,7 @@ public:
 
     // get target node ID here, where tid is available
     // necessary for hpc synapses using TargetIdentifierIndex
-    dict[ names::target ] = C_[ lcid ].get_target( tid )->get_node_id();
+    dict[ names::target ] = std::vector< long >( C_[ lcid ].get_target( tid )->get_node_id() );
   }
 
   void

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -255,7 +255,7 @@ public:
 
     // get target node ID here, where tid is available
     // necessary for hpc synapses using TargetIdentifierIndex
-    dict[ names::target ] = std::vector< long >( C_[ lcid ].get_target( tid )->get_node_id() );
+    dict[ names::target ] = static_cast< long >( C_[ lcid ].get_target( tid )->get_node_id() );
   }
 
   void

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -101,9 +101,9 @@ GenericConnectorModel< ConnectionT >::get_status( Dictionary& d ) const
   // then get default properties for individual synapses
   default_connection_.get_status( d );
 
-  d[ names::receptor_type ] = std::vector< long >( receptor_type_ );
+  d[ names::receptor_type ] = static_cast< long >( receptor_type_ );
   d[ names::synapse_model ] = name_;
-  d[ names::synapse_modelid ] = std::vector< long >( kernel().model_manager.get_synapse_model_id( name_ ) );
+  d[ names::synapse_modelid ] = static_cast< long >( kernel().model_manager.get_synapse_model_id( name_ ) );
   d[ names::requires_symmetric ] = has_property( ConnectionModelProperties::REQUIRES_SYMMETRIC );
   d[ names::has_delay ] = has_property( ConnectionModelProperties::HAS_DELAY );
 }

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -101,9 +101,9 @@ GenericConnectorModel< ConnectionT >::get_status( Dictionary& d ) const
   // then get default properties for individual synapses
   default_connection_.get_status( d );
 
-  d[ names::receptor_type ] = receptor_type_;
+  d[ names::receptor_type ] = std::vector< long >( receptor_type_ );
   d[ names::synapse_model ] = name_;
-  d[ names::synapse_modelid ] = kernel().model_manager.get_synapse_model_id( name_ );
+  d[ names::synapse_modelid ] = std::vector< long >( kernel().model_manager.get_synapse_model_id( name_ ) );
   d[ names::requires_symmetric ] = has_property( ConnectionModelProperties::REQUIRES_SYMMETRIC );
   d[ names::has_delay ] = has_property( ConnectionModelProperties::HAS_DELAY );
 }

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -250,7 +250,7 @@ Dictionary
 GenericModel< ElementT >::get_status_()
 {
   Dictionary d = proto_.get_status_base();
-  d[ names::elementsize ] = sizeof( ElementT );
+  d[ names::elementsize ] = static_cast< long >( sizeof( ElementT ) );
   return d;
 }
 

--- a/nestkernel/grid_layer.h
+++ b/nestkernel/grid_layer.h
@@ -213,7 +213,10 @@ GridLayer< D >::get_status( Dictionary& d, NodeCollection const* const nc ) cons
 {
   Layer< D >::get_status( d, nc );
 
-  d[ names::shape ] = std::vector< size_t >( dims_.get_vector() );
+  std::vector< long > dtmp;
+  const auto& dv = dims_.get_vector();
+  std::copy( dv.begin(), dv.end(), std::back_inserter( dtmp ) );
+  d[ names::shape ] = dtmp;
 }
 
 template < int D >

--- a/nestkernel/kernel_manager.cpp
+++ b/nestkernel/kernel_manager.cpp
@@ -309,11 +309,11 @@ nest::KernelManager::get_status( Dictionary& dict )
   dict[ "build_info" ] = get_build_info_();
   if ( NEST_HOSTOS == std::string( "linux" ) )
   {
-    dict[ "memory_size" ] = get_memsize_linux_();
+    dict[ "memory_size" ] = static_cast< long >( get_memsize_linux_() );
   }
   else if ( NEST_HOSTOS == std::string( "darwin" ) )
   {
-    dict[ "memory_size" ] = get_memsize_darwin_();
+    dict[ "memory_size" ] = static_cast< long >( get_memsize_darwin_() );
   }
   else
   {

--- a/nestkernel/layer_impl.h
+++ b/nestkernel/layer_impl.h
@@ -108,7 +108,7 @@ Layer< D >::get_status( Dictionary& d, NodeCollection const* const nc ) const
   {
     // This is for backward compatibility with some tests and scripts
     // TODO: Rename parameter
-    d[ names::network_size ] = nc->size();
+    d[ names::network_size ] = static_cast< long >( nc->size() );
   }
 }
 
@@ -335,7 +335,7 @@ Layer< D >::dump_connections( std::ostream& out,
       conn.get_synapse_model_id(),
       conn.get_port() );
 
-    const auto target_node_id = result_dict.get< size_t >( names::target );
+    const auto target_node_id = result_dict.get< long >( names::target );
     const auto weight = result_dict.get< double >( names::weight );
     const auto delay = result_dict.get< double >( names::delay );
 

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -131,7 +131,7 @@ ModelManager::get_status( Dictionary& dict )
 
   // syn_ids start at 0. But because the maximal value is used as invalid_synindex,
   // we only have MAX_SYN_ID possible models.
-  dict[ names::max_num_syn_models ] = MAX_SYN_ID;
+  dict[ names::max_num_syn_models ] = static_cast< long >( MAX_SYN_ID );
 }
 
 void
@@ -144,12 +144,12 @@ ModelManager::copy_model( const std::string& old_name, const std::string& new_na
 
   if ( modeldict_.known( old_name ) )
   {
-    const size_t old_id = modeldict_.get< size_t >( old_name );
+    const size_t old_id = modeldict_.get< long >( old_name );
     copy_node_model_( old_id, new_name, params );
   }
   else if ( synapsedict_.known( old_name ) )
   {
-    const size_t old_id = synapsedict_.get< size_t >( old_name );
+    const size_t old_id = synapsedict_.get< long >( old_name );
     copy_connection_model_( old_id, new_name, params );
   }
   else
@@ -171,7 +171,7 @@ ModelManager::register_node_model_( Model* model )
   model->set_threads();
 
   node_models_.push_back( model );
-  modeldict_[ name ] = id;
+  modeldict_[ name ] = static_cast< long >( id );
 
 #pragma omp parallel
   {
@@ -193,7 +193,7 @@ ModelManager::copy_node_model_( const size_t old_id, const std::string& new_name
   new_model->set_model_id( new_id );
 
   node_models_.push_back( new_model );
-  modeldict_[ new_name ] = new_id;
+  modeldict_[ new_name ] = static_cast< long >( new_id );
 
   set_node_defaults_( new_id, params );
 
@@ -219,7 +219,7 @@ ModelManager::copy_connection_model_( const size_t old_id, const std::string& ne
     throw KernelException( "Synapse model count exceeded" );
   }
 
-  synapsedict_[ new_name ] = new_id;
+  synapsedict_[ new_name ] = static_cast< long >( new_id );
 
 #pragma omp parallel
   {
@@ -239,13 +239,13 @@ ModelManager::set_model_defaults( const std::string& name, const Dictionary& par
   size_t id;
   if ( modeldict_.known( name ) )
   {
-    id = modeldict_.get< size_t >( name );
+    id = modeldict_.get< long >( name );
     set_node_defaults_( id, params );
     return true;
   }
   else if ( synapsedict_.known( name ) )
   {
-    id = synapsedict_.get< synindex >( name );
+    id = synapsedict_.get< long >( name );
     set_synapse_defaults_( id, params );
     return true;
   }
@@ -311,7 +311,7 @@ ModelManager::get_node_model_id( const std::string model_name ) const
 {
   if ( modeldict_.known( model_name ) )
   {
-    return modeldict_.get< size_t >( model_name );
+    return modeldict_.get< long >( model_name );
   }
 
   throw UnknownModelName( model_name );
@@ -322,7 +322,7 @@ ModelManager::get_synapse_model_id( std::string model_name )
 {
   if ( synapsedict_.known( model_name ) )
   {
-    return synapsedict_.get< synindex >( model_name );
+    return synapsedict_.get< long >( model_name );
   }
 
   throw UnknownSynapseType( model_name );
@@ -342,7 +342,7 @@ ModelManager::get_connector_defaults( synindex syn_id ) const
     connection_models_[ t ][ syn_id ]->get_status( dict );
   }
 
-  dict[ names::num_connections ] = kernel().connection_manager.get_num_connections( syn_id );
+  dict[ names::num_connections ] = static_cast< long >( kernel().connection_manager.get_num_connections( syn_id ) );
   dict[ names::element_type ] = std::string( "synapse" );
 
   return dict;

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -98,7 +98,7 @@ ModelManager::register_specific_connection_model_( const std::string& name )
     throw KernelException( "Synapse model count exceeded" );
   }
 
-  synapsedict_[ name ] = new_syn_id;
+  synapsedict_[ name ] = static_cast< long >( new_syn_id );
 
 #pragma omp parallel
   {

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -240,7 +240,11 @@ nest::MPIManager::set_status( const Dictionary& dict )
 
   dict.update_value( names::growth_factor_buffer_spike_data, growth_factor_buffer_spike_data_ );
   dict.update_value( names::growth_factor_buffer_target_data, growth_factor_buffer_target_data_ );
-  dict.update_value( names::max_buffer_size_target_data, max_buffer_size_target_data_ );
+  long mbstd = 0;
+  if ( dict.update_value( names::max_buffer_size_target_data, mbstd ) )
+  {
+    max_buffer_size_target_data_ = mbstd;
+  };
   dict.update_value( names::shrink_factor_buffer_spike_data, shrink_factor_buffer_spike_data_ );
 }
 
@@ -250,11 +254,13 @@ nest::MPIManager::get_status( Dictionary& dict )
   dict[ names::num_processes ] = num_processes_;
   dict[ names::mpi_rank ] = rank_;
   dict[ names::adaptive_target_buffers ] = adaptive_target_buffers_;
-  dict[ names::buffer_size_target_data ] = buffer_size_target_data_;
-  dict[ names::buffer_size_spike_data ] = buffer_size_spike_data_;
-  dict[ names::send_buffer_size_secondary_events ] = get_send_buffer_size_secondary_events_in_int();
-  dict[ names::recv_buffer_size_secondary_events ] = get_recv_buffer_size_secondary_events_in_int();
-  dict[ names::max_buffer_size_target_data ] = max_buffer_size_target_data_;
+  dict[ names::buffer_size_target_data ] = static_cast< long >( buffer_size_target_data_ );
+  dict[ names::buffer_size_spike_data ] = static_cast< long >( buffer_size_spike_data_ );
+  dict[ names::send_buffer_size_secondary_events ] =
+    static_cast< long >( get_send_buffer_size_secondary_events_in_int() );
+  dict[ names::recv_buffer_size_secondary_events ] =
+    static_cast< long >( get_recv_buffer_size_secondary_events_in_int() );
+  dict[ names::max_buffer_size_target_data ] = static_cast< long >( max_buffer_size_target_data_ );
   dict[ names::growth_factor_buffer_spike_data ] = growth_factor_buffer_spike_data_;
   dict[ names::growth_factor_buffer_target_data ] = growth_factor_buffer_target_data_;
 }

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -240,11 +240,17 @@ nest::MPIManager::set_status( const Dictionary& dict )
 
   dict.update_value( names::growth_factor_buffer_spike_data, growth_factor_buffer_spike_data_ );
   dict.update_value( names::growth_factor_buffer_target_data, growth_factor_buffer_target_data_ );
+
   long mbstd = 0;
   if ( dict.update_value( names::max_buffer_size_target_data, mbstd ) )
   {
+    if ( mbstd < 0 )
+    {
+      throw BadProperty( "max_buffer_size_target_data ≥ 0 required." );
+    }
     max_buffer_size_target_data_ = mbstd;
   };
+
   dict.update_value( names::shrink_factor_buffer_spike_data, shrink_factor_buffer_spike_data_ );
 }
 

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -164,12 +164,19 @@ get_kernel_status()
   return d;
 }
 
+template < class... Ts >
+struct overloaded : Ts...
+{
+  using Ts::operator()...;
+};
+
 // TODO: Add the possibility to filter for specific keys
 Dictionary
 get_nc_status( NodeCollectionPTR nc )
 {
   Dictionary result;
   const size_t num_nodes = nc->size();
+
 
   size_t node_index = 0;
   for ( auto it = nc->begin(); it < nc->end(); ++it, ++node_index )
@@ -181,29 +188,31 @@ get_nc_status( NodeCollectionPTR nc )
       for ( const auto& kv_pair : node_status )
       {
         // Visit the variant to determine type T
-        std::visit(
-          [ &result, &kv_pair, num_nodes ]( const auto& val )
-          {
-            using T = std::decay_t< decltype( val ) >;
+        std::visit( overloaded { [ &result, &kv_pair, num_nodes ]( const auto& val )
+                      {
+                        using T = std::decay_t< decltype( val ) >;
 
-            if constexpr ( not DictionarySchema::is_defined_scalar< T > )
-            {
-              // Logic for Vectors: Explicitly forbidden
-              // throw std::runtime_error( String::compose(
-              //  "Invalid Schema: Key '%1' contains a vector, but only scalar values are allowed.", kv_pair.first ) );
-            }
-            else
-            {
-              // Create vector<T> of size N
-              std::vector< T > vec( num_nodes );
+                        // Create vector<T> of size N
+                        std::vector< T > vec( num_nodes );
 
-              // Assign the first value
-              vec[ 0 ] = val;
+                        // Assign the first value
+                        vec[ 0 ] = val;
 
-              // Store in result
-              result[ kv_pair.first ] = std::move( vec );
-            }
-          },
+                        // Store in result
+                        result[ kv_pair.first ] = std::move( vec );
+                      },
+                      [ &kv_pair ]< typename Q >( const std::vector< std::vector< std::vector< std::vector< Q > > > >& )
+                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', vvvvQ", kv_pair.first ) ); },
+                      [ &kv_pair ]( const std::vector< std::shared_ptr< nest::NodeCollection > >& )
+                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', vNC", kv_pair.first ) ); },
+                      [ &kv_pair ]( const std::shared_ptr< nest::Parameter >& )
+                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', P", kv_pair.first ) ); },
+                      [ &kv_pair ]( const VerbosityLevel& )
+                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', VL", kv_pair.first ) ); },
+                      [ &kv_pair ]( const EmptyList& )
+                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', EL", kv_pair.first ) ); }
+
+                    },
           kv_pair.second.item );
       }
     }
@@ -217,41 +226,42 @@ get_nc_status( NodeCollectionPTR nc )
         if ( map_it == result.end() )
         {
           continue;
-          // throw std::runtime_error( String::compose( "Sparse data detected: New key '%1' found late at index %2.",
-          //   kv_pair.first,
-          //   std::to_string( node_index ) ) );
+          throw std::runtime_error( String::compose( "Sparse data detected: New key '%1' found late at index %2.",
+            kv_pair.first,
+            std::to_string( node_index ) ) );
         }
 
         // We visit the input value and try to cast the existing vector to matching type.
-        std::visit(
-          [ &map_it, node_index, key = kv_pair.first ]( const auto& val )
-          {
-            using T = std::decay_t< decltype( val ) >;
+        std::visit( overloaded { [ &map_it, node_index, key = kv_pair.first ]( const auto& val )
+                      {
+                        using T = std::decay_t< decltype( val ) >;
 
-            if constexpr ( not DictionarySchema::is_defined_scalar< T > )
-            {
-              // Logic for Vectors: Explicitly forbidden
-              // throw std::runtime_error( String::compose(
-              //  "Invalid Schema: Key '%1' contains a vector, but only scalar values are allowed.", key ) );
-            }
-            else
-            {
-              try
-              {
-                // Throws std::bad_variant_access if Node N has a different type than Node 0 (e.g., int vs double)
-                auto& vec = std::get< std::vector< T > >( map_it->second.item );
-                vec[ node_index ] = val;
-              }
-              catch ( const std::bad_variant_access& )
-              {
-                throw std::runtime_error( String::compose(
-                  "Type mismatch detected for key '%1' at index %2. Retrieving node collection status data "
-                  "only works for homogeneous neuron models.",
-                  key,
-                  std::to_string( node_index ) ) );
-              }
-            }
-          },
+                        try
+                        {
+                          // Throws std::bad_variant_access if Node N has a different type than Node 0 (e.g., int vs
+                          // double)
+                          auto& vec = std::get< std::vector< T > >( map_it->second.item );
+                          vec[ node_index ] = val;
+                        }
+                        catch ( const std::bad_variant_access& )
+                        {
+                          throw std::runtime_error( String::compose(
+                            "Type mismatch detected for key '%1' at index %2. Retrieving node collection status data "
+                            "only works for homogeneous neuron models.",
+                            key,
+                            std::to_string( node_index ) ) );
+                        }
+                      },
+                      [ &kv_pair ]< typename Q >( const std::vector< std::vector< std::vector< std::vector< Q > > > >& )
+                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', vvvvQ", kv_pair.first ) ); },
+                      [ &kv_pair ]( const std::vector< std::shared_ptr< nest::NodeCollection > >& )
+                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', vNC", kv_pair.first ) ); },
+                      [ &kv_pair ]( const std::shared_ptr< nest::Parameter >& )
+                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', P", kv_pair.first ) ); },
+                      [ &kv_pair ]( const VerbosityLevel& )
+                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', VL", kv_pair.first ) ); },
+                      [ &kv_pair ]( const EmptyList& )
+                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', EL", kv_pair.first ) ); } },
           kv_pair.second.item );
       }
     }

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -189,8 +189,8 @@ get_nc_status( NodeCollectionPTR nc )
             if constexpr ( not DictionarySchema::is_defined_scalar< T > )
             {
               // Logic for Vectors: Explicitly forbidden
-              throw std::runtime_error( String::compose(
-                "Invalid Schema: Key '%1' contains a vector, but only scalar values are allowed.", kv_pair.first ) );
+              // throw std::runtime_error( String::compose(
+              //  "Invalid Schema: Key '%1' contains a vector, but only scalar values are allowed.", kv_pair.first ) );
             }
             else
             {
@@ -216,9 +216,10 @@ get_nc_status( NodeCollectionPTR nc )
         // Strict Key Existence Check
         if ( map_it == result.end() )
         {
-          throw std::runtime_error( String::compose( "Sparse data detected: New key '%1' found late at index %2.",
-            kv_pair.first,
-            std::to_string( node_index ) ) );
+          continue;
+          // throw std::runtime_error( String::compose( "Sparse data detected: New key '%1' found late at index %2.",
+          //   kv_pair.first,
+          //   std::to_string( node_index ) ) );
         }
 
         // We visit the input value and try to cast the existing vector to matching type.
@@ -230,8 +231,8 @@ get_nc_status( NodeCollectionPTR nc )
             if constexpr ( not DictionarySchema::is_defined_scalar< T > )
             {
               // Logic for Vectors: Explicitly forbidden
-              throw std::runtime_error( String::compose(
-                "Invalid Schema: Key '%1' contains a vector, but only scalar values are allowed.", key ) );
+              // throw std::runtime_error( String::compose(
+              //  "Invalid Schema: Key '%1' contains a vector, but only scalar values are allowed.", key ) );
             }
             else
             {
@@ -468,7 +469,7 @@ get_metadata( const NodeCollectionPTR nc )
   if ( meta.get() )
   {
     meta->get_status( status_dict, nc );
-    status_dict[ names::network_size ] = nc->size();
+    status_dict[ names::network_size ] = static_cast< long >( nc->size() );
   }
   return status_dict;
 }

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -164,33 +164,6 @@ get_kernel_status()
   return d;
 }
 
-template < class... Ts >
-struct overloaded : Ts...
-{
-  using Ts::operator()...;
-};
-
-template < typename T >
-T
-default_result_value()
-{
-  return T {};
-}
-
-template <>
-double
-default_result_value< double >()
-{
-  return numerics::nan;
-}
-
-template <>
-long
-default_result_value< long >()
-{
-  return -1;
-}
-
 // TODO: Add the possibility to filter for specific keys
 Dictionary
 get_nc_status( NodeCollectionPTR nc )
@@ -215,13 +188,15 @@ get_nc_status( NodeCollectionPTR nc )
         }
         catch ( const std::bad_variant_access& e )
         {
-          throw std::runtime_error( "did not find anyvector" );
+          throw std::runtime_error( String::compose(
+            "result[%1] contained type %2, expected vector<any_type>.", key, debug_type( p->second.item ) ) );
         }
       }
       else
       {
         // key does not exist yet
-        auto new_entry = AnyVector( num_nodes );
+        auto new_entry =
+          AnyVector( num_nodes ); // all elements initialized with std::monostate, translates to None in Python
         new_entry[ node_index ] = entry.item;
         result[ key ] = new_entry;
       }

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -134,7 +134,7 @@ pprint_to_string( NodeCollectionPTR nc )
 {
   assert( nc );
   std::stringstream stream;
-  stream << nc;
+  nc->print_me( stream );
   return stream.str();
 }
 

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -202,67 +202,29 @@ get_nc_status( NodeCollectionPTR nc )
   for ( auto it = nc->begin(); it < nc->end(); ++it, ++node_index )
   {
     const auto node_status = get_node_status( ( *it ).node_id );
-
-    for ( const auto& kv_pair : node_status )
+    for ( const auto& [ key, entry ] : node_status )
     {
-      // Visit the variant to determine type T
-      std::visit(
-        overloaded { [ &result, &kv_pair, num_nodes, node_index ]( const auto& val )
-          {
-            using T = std::decay_t< decltype( val ) >;
-
-            auto map_it = result.find( kv_pair.first );
-
-            if ( map_it == result.end() )
-            {
-              std::vector< T > vec( num_nodes, default_result_value< T >() );
-              result[ kv_pair.first ] = std::move( vec );
-
-              // TODO: Fix to avoid running find again
-              map_it = result.find( kv_pair.first );
-            }
-
-            try
-            {
-              // Throws std::bad_variant_access if Node N has a different type than Node 0 (e.g., int vs
-              // double)
-              auto& vec = std::get< std::vector< T > >( map_it->second.item );
-              vec[ node_index ] = val;
-            }
-            catch ( const std::bad_variant_access& )
-            {
-              throw std::runtime_error( String::compose(
-                "Type mismatch detected for key '%1' at index %2. Retrieving node collection status data "
-                "for heterogeneous collections as long as nodes have the same data types "
-                "for properties of the same name.",
-                kv_pair.first,
-                node_index ) );
-            }
-          },
-          [ &kv_pair, node_index ]< typename Q >( const std::vector< std::vector< std::vector< std::vector< Q > > > >& )
-          {
-            throw std::runtime_error(
-              String::compose( "IDX %1: Key '%2', vvvvQ", std::to_string( node_index ), kv_pair.first ) );
-          },
-          [ &kv_pair, node_index ]( const std::vector< std::shared_ptr< nest::NodeCollection > >& )
-          {
-            throw std::runtime_error(
-              String::compose( "IDX %1: Key '%2', vNC", std::to_string( node_index ), kv_pair.first ) );
-          },
-          [ &kv_pair, node_index ]( const std::shared_ptr< nest::Parameter >& ) {
-            throw std::runtime_error(
-              String::compose( "IDX %1: Key '%2', P", std::to_string( node_index ), kv_pair.first ) );
-          },
-          [ &kv_pair, node_index ]( const VerbosityLevel& ) {
-            throw std::runtime_error(
-              String::compose( "IDX %1: Key '%2', VL", std::to_string( node_index ), kv_pair.first ) );
-          },
-          [ &kv_pair, node_index ]( const EmptyList& )
-          {
-            throw std::runtime_error(
-              String::compose( "IDX %1: Key '%2', EL", std::to_string( node_index ), kv_pair.first ) );
-          } },
-        kv_pair.second.item );
+      const auto p = result.find( key );
+      if ( p != result.end() )
+      {
+        // key exists
+        try
+        {
+          auto& v = std::get< AnyVector >( p->second.item );
+          v[ node_index ] = entry.item;
+        }
+        catch ( const std::bad_variant_access& e )
+        {
+          throw std::runtime_error( "did not find anyvector" );
+        }
+      }
+      else
+      {
+        // key does not exist yet
+        auto new_entry = AnyVector( num_nodes );
+        new_entry[ node_index ] = entry.item;
+        result[ key ] = new_entry;
+      }
     }
   }
 

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -170,6 +170,27 @@ struct overloaded : Ts...
   using Ts::operator()...;
 };
 
+template < typename T >
+T
+default_result_value()
+{
+  return T {};
+}
+
+template <>
+double
+default_result_value< double >()
+{
+  return numerics::nan;
+}
+
+template <>
+long
+default_result_value< long >()
+{
+  return -1;
+}
+
 // TODO: Add the possibility to filter for specific keys
 Dictionary
 get_nc_status( NodeCollectionPTR nc )
@@ -177,93 +198,71 @@ get_nc_status( NodeCollectionPTR nc )
   Dictionary result;
   const size_t num_nodes = nc->size();
 
-
   size_t node_index = 0;
   for ( auto it = nc->begin(); it < nc->end(); ++it, ++node_index )
   {
     const auto node_status = get_node_status( ( *it ).node_id );
 
-    if ( node_index == 0 ) // schema definition step
+    for ( const auto& kv_pair : node_status )
     {
-      for ( const auto& kv_pair : node_status )
-      {
-        // Visit the variant to determine type T
-        std::visit( overloaded { [ &result, &kv_pair, num_nodes ]( const auto& val )
-                      {
-                        using T = std::decay_t< decltype( val ) >;
+      // Visit the variant to determine type T
+      std::visit(
+        overloaded { [ &result, &kv_pair, num_nodes, node_index ]( const auto& val )
+          {
+            using T = std::decay_t< decltype( val ) >;
 
-                        // Create vector<T> of size N
-                        std::vector< T > vec( num_nodes );
+            auto map_it = result.find( kv_pair.first );
 
-                        // Assign the first value
-                        vec[ 0 ] = val;
+            if ( map_it == result.end() )
+            {
+              std::vector< T > vec( num_nodes, default_result_value< T >() );
+              result[ kv_pair.first ] = std::move( vec );
 
-                        // Store in result
-                        result[ kv_pair.first ] = std::move( vec );
-                      },
-                      [ &kv_pair ]< typename Q >( const std::vector< std::vector< std::vector< std::vector< Q > > > >& )
-                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', vvvvQ", kv_pair.first ) ); },
-                      [ &kv_pair ]( const std::vector< std::shared_ptr< nest::NodeCollection > >& )
-                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', vNC", kv_pair.first ) ); },
-                      [ &kv_pair ]( const std::shared_ptr< nest::Parameter >& )
-                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', P", kv_pair.first ) ); },
-                      [ &kv_pair ]( const VerbosityLevel& )
-                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', VL", kv_pair.first ) ); },
-                      [ &kv_pair ]( const EmptyList& )
-                      { throw std::runtime_error( String::compose( "IDX 0: Key '%1', EL", kv_pair.first ) ); }
+              // TODO: Fix to avoid running find again
+              map_it = result.find( kv_pair.first );
+            }
 
-                    },
-          kv_pair.second.item );
-      }
-    }
-    else // Fill step (including validation)
-    {
-      for ( const auto& kv_pair : node_status )
-      {
-        auto map_it = result.find( kv_pair.first );
-
-        // Strict Key Existence Check
-        if ( map_it == result.end() )
-        {
-          continue;
-          throw std::runtime_error( String::compose( "Sparse data detected: New key '%1' found late at index %2.",
-            kv_pair.first,
-            std::to_string( node_index ) ) );
-        }
-
-        // We visit the input value and try to cast the existing vector to matching type.
-        std::visit( overloaded { [ &map_it, node_index, key = kv_pair.first ]( const auto& val )
-                      {
-                        using T = std::decay_t< decltype( val ) >;
-
-                        try
-                        {
-                          // Throws std::bad_variant_access if Node N has a different type than Node 0 (e.g., int vs
-                          // double)
-                          auto& vec = std::get< std::vector< T > >( map_it->second.item );
-                          vec[ node_index ] = val;
-                        }
-                        catch ( const std::bad_variant_access& )
-                        {
-                          throw std::runtime_error( String::compose(
-                            "Type mismatch detected for key '%1' at index %2. Retrieving node collection status data "
-                            "only works for homogeneous neuron models.",
-                            key,
-                            std::to_string( node_index ) ) );
-                        }
-                      },
-                      [ &kv_pair ]< typename Q >( const std::vector< std::vector< std::vector< std::vector< Q > > > >& )
-                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', vvvvQ", kv_pair.first ) ); },
-                      [ &kv_pair ]( const std::vector< std::shared_ptr< nest::NodeCollection > >& )
-                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', vNC", kv_pair.first ) ); },
-                      [ &kv_pair ]( const std::shared_ptr< nest::Parameter >& )
-                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', P", kv_pair.first ) ); },
-                      [ &kv_pair ]( const VerbosityLevel& )
-                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', VL", kv_pair.first ) ); },
-                      [ &kv_pair ]( const EmptyList& )
-                      { throw std::runtime_error( String::compose( "IDX n: Key '%1', EL", kv_pair.first ) ); } },
-          kv_pair.second.item );
-      }
+            try
+            {
+              // Throws std::bad_variant_access if Node N has a different type than Node 0 (e.g., int vs
+              // double)
+              auto& vec = std::get< std::vector< T > >( map_it->second.item );
+              vec[ node_index ] = val;
+            }
+            catch ( const std::bad_variant_access& )
+            {
+              throw std::runtime_error( String::compose(
+                "Type mismatch detected for key '%1' at index %2. Retrieving node collection status data "
+                "for heterogeneous collections as long as nodes have the same data types "
+                "for properties of the same name.",
+                kv_pair.first,
+                node_index ) );
+            }
+          },
+          [ &kv_pair, node_index ]< typename Q >( const std::vector< std::vector< std::vector< std::vector< Q > > > >& )
+          {
+            throw std::runtime_error(
+              String::compose( "IDX %1: Key '%2', vvvvQ", std::to_string( node_index ), kv_pair.first ) );
+          },
+          [ &kv_pair, node_index ]( const std::vector< std::shared_ptr< nest::NodeCollection > >& )
+          {
+            throw std::runtime_error(
+              String::compose( "IDX %1: Key '%2', vNC", std::to_string( node_index ), kv_pair.first ) );
+          },
+          [ &kv_pair, node_index ]( const std::shared_ptr< nest::Parameter >& ) {
+            throw std::runtime_error(
+              String::compose( "IDX %1: Key '%2', P", std::to_string( node_index ), kv_pair.first ) );
+          },
+          [ &kv_pair, node_index ]( const VerbosityLevel& ) {
+            throw std::runtime_error(
+              String::compose( "IDX %1: Key '%2', VL", std::to_string( node_index ), kv_pair.first ) );
+          },
+          [ &kv_pair, node_index ]( const EmptyList& )
+          {
+            throw std::runtime_error(
+              String::compose( "IDX %1: Key '%2', EL", std::to_string( node_index ), kv_pair.first ) );
+          } },
+        kv_pair.second.item );
     }
   }
 

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -451,12 +451,12 @@ connect_tripartite( NodeCollectionPTR sources,
 }
 
 void
-connect_arrays( long* sources,
-  long* targets,
-  double* weights,
-  double* delays,
+connect_arrays( const long* sources,
+  const long* targets,
+  const double* weights,
+  const double* delays,
   const std::vector< std::string >& p_keys,
-  double* p_values,
+  const double* p_values,
   size_t n,
   const std::string& syn_model )
 {

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -134,7 +134,7 @@ pprint_to_string( NodeCollectionPTR nc )
 {
   assert( nc );
   std::stringstream stream;
-  nc->print_me( stream );
+  stream << nc;
   return stream.str();
 }
 

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -158,12 +158,12 @@ void connect_tripartite( NodeCollectionPTR sources,
  * and M additional synapse parameters, p_keys has a size of M, and the p_values array
  * has length of M*n.
  */
-void connect_arrays( long* sources,
-  long* targets,
-  double* weights,
-  double* delays,
+void connect_arrays( const long* sources,
+  const long* targets,
+  const double* weights,
+  const double* delays,
   const std::vector< std::string >& p_keys,
-  double* p_values,
+  const double* p_values,
   size_t n,
   const std::string& syn_model );
 

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -147,8 +147,8 @@ Node::get_status_base()
   dict[ names::local ] = kernel().node_manager.is_local_node( this );
   dict[ names::model ] = get_name();
   dict[ names::model_id ] = get_model_id();
-  dict[ names::global_id ] = get_node_id();
-  dict[ names::vp ] = get_vp();
+  dict[ names::global_id ] = static_cast< long >( get_node_id() );
+  dict[ names::vp ] = static_cast< long >( get_vp() );
   dict[ names::element_type ] = get_element_type();
 
   // add information available only for local nodes
@@ -156,8 +156,8 @@ Node::get_status_base()
   {
     dict[ names::frozen ] = is_frozen();
     dict[ names::node_uses_wfr ] = node_uses_wfr();
-    dict[ names::thread_local_id ] = get_thread_lid();
-    dict[ names::thread ] = get_thread();
+    dict[ names::thread_local_id ] = static_cast< long >( get_thread_lid() );
+    dict[ names::thread ] = static_cast< long >( get_thread() );
   }
 
   // now call the child class' hook

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -673,6 +673,12 @@ NodeCollectionPrimitive::slice( size_t start, size_t end, size_t stride ) const
   return sliced_nc;
 }
 
+void
+NodeCollectionPrimitive::print_me( std::ostream& os ) const
+{
+  os << *this;
+}
+
 std::ostream&
 operator<<( std::ostream& out, const NodeCollectionPrimitive& nc )
 {
@@ -1344,6 +1350,12 @@ NodeCollectionComposite::has_proxies() const
 {
   return std::all_of(
     parts_.begin(), parts_.end(), []( const NodeCollectionPrimitive& prim ) { return prim.has_proxies(); } );
+}
+
+void
+NodeCollectionComposite::print_me( std::ostream& os ) const
+{
+  os << *this;
 }
 
 std::ostream&

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -673,25 +673,19 @@ NodeCollectionPrimitive::slice( size_t start, size_t end, size_t stride ) const
   return sliced_nc;
 }
 
-void
-NodeCollectionPrimitive::print_me( std::ostream& os ) const
-{
-  os << *this;
-}
-
 std::ostream&
-operator<<( std::ostream& out, const NodeCollectionPrimitive& nc )
+NodeCollectionPrimitive::print_me( std::ostream& out ) const
 {
   out << "NodeCollection(";
-  if ( nc.empty() )
+  if ( empty() )
   {
     out << "<empty>";
   }
   else
   {
-    std::string metadata = nc.metadata_.get() ? nc.metadata_->get_type() : "None";
+    const std::string metadata = metadata_.get() ? metadata_->get_type() : "None";
     out << "metadata=" << metadata << ", ";
-    nc.print_primitive( out );
+    print_primitive( out );
   }
   out << ")";
 
@@ -1352,20 +1346,14 @@ NodeCollectionComposite::has_proxies() const
     parts_.begin(), parts_.end(), []( const NodeCollectionPrimitive& prim ) { return prim.has_proxies(); } );
 }
 
-void
-NodeCollectionComposite::print_me( std::ostream& os ) const
-{
-  os << *this;
-}
-
 std::ostream&
-operator<<( std::ostream& out, const NodeCollectionComposite& nc )
+NodeCollectionComposite::print_me( std::ostream& out ) const
 {
-  std::string metadata = nc.parts_[ 0 ].get_metadata().get() ? nc.parts_[ 0 ].get_metadata()->get_type() : "None";
+  std::string metadata = parts_[ 0 ].get_metadata().get() ? parts_[ 0 ].get_metadata()->get_type() : "None";
   std::string nc_str = "NodeCollection(";
   std::string space( nc_str.size(), ' ' );
 
-  if ( nc.is_sliced_ )
+  if ( is_sliced_ )
   {
     size_t current_part = 0;
     size_t current_offset = 0;
@@ -1373,19 +1361,19 @@ operator<<( std::ostream& out, const NodeCollectionComposite& nc )
     size_t primitive_last = 0;
 
     size_t primitive_size = 0;
-    NodeIDTriple first_in_primitive = *nc.begin();
+    NodeIDTriple first_in_primitive = *begin();
 
     std::vector< std::string > string_vector;
 
     out << nc_str << "metadata=" << metadata << ",";
 
-    const auto end_it = nc.end();
-    for ( nc_const_iterator it = nc.begin(); it < end_it; ++it )
+    const auto end_it = end();
+    for ( nc_const_iterator it = begin(); it < end_it; ++it )
     {
       std::tie( current_part, current_offset ) = it.get_part_offset();
       if ( current_part != previous_part ) // New primitive
       {
-        if ( it > nc.begin() )
+        if ( it > begin() )
         {
           // Need to count the primitive, so can't start at begin()
           out << "\n" + space
@@ -1399,9 +1387,9 @@ operator<<( std::ostream& out, const NodeCollectionComposite& nc )
           {
             out << "first=" << first_in_primitive.node_id << ", last=";
             out << primitive_last;
-            if ( nc.stride_ > 1 )
+            if ( stride_ > 1 )
             {
-              out << ", step=" << nc.stride_ << ";";
+              out << ", step=" << stride_ << ";";
             }
           }
         }
@@ -1427,9 +1415,9 @@ operator<<( std::ostream& out, const NodeCollectionComposite& nc )
     {
       out << "first=" << first_in_primitive.node_id << ", last=";
       out << primitive_last;
-      if ( nc.stride_ > 1 )
+      if ( stride_ > 1 )
       {
-        out << ", step=" << nc.stride_;
+        out << ", step=" << stride_;
       }
     }
   }
@@ -1437,9 +1425,9 @@ operator<<( std::ostream& out, const NodeCollectionComposite& nc )
   {
     // Unsliced Composite NodeCollection
     out << nc_str << "metadata=" << metadata << ",";
-    for ( auto it = nc.parts_.begin(); it < nc.parts_.end(); ++it )
+    for ( auto it = parts_.begin(); it < parts_.end(); ++it )
     {
-      if ( it == nc.parts_.end() - 1 )
+      if ( it == parts_.end() - 1 )
       {
         out << "\n" + space;
         it->print_primitive( out );

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -619,6 +619,14 @@ public:
   bool valid() const;
 
   /**
+   * Print out the contents of the NodeCollection in a pretty and informative
+   * way.
+   *
+   * @note Important for resolution from NodeCollectionPTR to subclasses.
+   */
+  virtual void print_me( std::ostream& ) const = 0;
+
+  /**
    * Get the node ID in the specified index in the NodeCollection.
    *
    * @param idx Index in the NodeCollection
@@ -863,6 +871,7 @@ public:
    */
   NodeCollectionPrimitive();
 
+  void print_me( std::ostream& ) const override;
   void print_primitive( std::ostream& ) const;
 
   size_t operator[]( const size_t ) const override;
@@ -1055,6 +1064,8 @@ public:
    * @param comp Composite to be copied.
    */
   NodeCollectionComposite( const NodeCollectionComposite& ) = default;
+
+  void print_me( std::ostream& ) const override;
 
   size_t operator[]( const size_t ) const override;
 

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -624,7 +624,7 @@ public:
    *
    * @note Important for resolution from NodeCollectionPTR to subclasses.
    */
-  virtual void print_me( std::ostream& ) const = 0;
+  virtual std::ostream& print_me( std::ostream& ) const = 0;
 
   /**
    * Get the node ID in the specified index in the NodeCollection.
@@ -871,7 +871,7 @@ public:
    */
   NodeCollectionPrimitive();
 
-  void print_me( std::ostream& ) const override;
+  std::ostream& print_me( std::ostream& ) const override;
   void print_primitive( std::ostream& ) const;
 
   size_t operator[]( const size_t ) const override;
@@ -922,11 +922,7 @@ public:
    * @return True if the other primitive overlaps, false otherwise.
    */
   bool overlapping( const NodeCollectionPrimitive& rhs ) const;
-
-  friend std::ostream& operator<<( std::ostream& out, const NodeCollectionPrimitive& nc );
 };
-
-std::ostream& operator<<( std::ostream& out, const NodeCollectionPrimitive& nc );
 
 NodeCollectionPTR operator+( NodeCollectionPTR lhs, NodeCollectionPTR rhs );
 
@@ -1065,7 +1061,7 @@ public:
    */
   NodeCollectionComposite( const NodeCollectionComposite& ) = default;
 
-  void print_me( std::ostream& ) const override;
+  std::ostream& print_me( std::ostream& ) const override;
 
   size_t operator[]( const size_t ) const override;
 
@@ -1107,11 +1103,14 @@ public:
   long get_nc_index( const size_t ) const override;
 
   bool has_proxies() const override;
-
-  friend std::ostream& operator<<( std::ostream& out, const NodeCollectionComposite& nc );
 };
 
-std::ostream& operator<<( std::ostream& out, const NodeCollectionComposite& nc );
+inline std::ostream&
+operator<<( std::ostream& out, const NodeCollectionPTR nc )
+{
+  return nc->print_me( out );
+}
+
 
 inline bool
 NodeCollection::operator!=( NodeCollectionPTR rhs ) const

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -746,7 +746,7 @@ NodeManager::set_status( size_t node_id, const Dictionary& d )
 void
 NodeManager::get_status( Dictionary& d )
 {
-  d[ names::network_size ] = size();
+  d[ names::network_size ] = static_cast< long >( size() );
   sw_construction_create_.get_status( d, names::time_construction_create, names::time_construction_create_cpu );
 }
 

--- a/nestkernel/recording_backend_memory.cpp
+++ b/nestkernel/recording_backend_memory.cpp
@@ -224,12 +224,12 @@ nest::RecordingBackendMemory::DeviceData::get_status( Dictionary& d ) const
     events = d.get< Dictionary >( names::events );
   }
 
-  auto& senders = events.get_vector< int >( names::senders );
+  auto& senders = events.get_vector< long >( names::senders );
   senders.insert( senders.end(), senders_.begin(), senders_.end() );
 
   if ( time_in_steps_ )
   {
-    auto& times = events.get_vector< int >( names::times );
+    auto& times = events.get_vector< long >( names::times );
     times.insert( times.end(), times_steps_.begin(), times_steps_.end() );
 
     auto& offsets = events.get_vector< double >( names::offsets );
@@ -248,7 +248,7 @@ nest::RecordingBackendMemory::DeviceData::get_status( Dictionary& d ) const
   }
   for ( size_t i = 0; i < long_values_.size(); ++i )
   {
-    auto& long_name = events.get_vector< int >( long_value_names_[ i ] );
+    auto& long_name = events.get_vector< long >( long_value_names_[ i ] );
     long_name.insert( long_name.end(), long_values_[ i ].begin(), long_values_[ i ].end() );
   }
 

--- a/nestkernel/recording_backend_sionlib.cpp
+++ b/nestkernel/recording_backend_sionlib.cpp
@@ -628,7 +628,19 @@ nest::RecordingBackendSIONlib::Parameters_::set( const RecordingBackendSIONlib&,
   d.update_value( names::buffer_size, buffer_size_ );
   d.update_value( names::sion_chunksize, sion_chunksize_ );
   d.update_value( names::sion_collective, sion_collective_ );
-  d.update_value( names::sion_n_files, sion_n_files_ );
+  long sion_n_files_long = sion_n_files_;
+  if (  d.update_value( names::sion_n_files, sion_n_files_long ) )
+  {
+    if ( sion_n_files_long < 1 ) 
+  {
+    throw BadProperty("sion_n_files >= 1 required.");
+  }
+    if ( sion_n_files_long > std::numeric_limits<int>::max() )
+  {
+    throw BadProperty(String::compose("sion_n_files <= %1 required", std::to_string(std::numeric_limits<int>::max())));
+  }
+    sion_n_files_ = static_cast<int>(sion_n_files_long);
+  }
 }
 
 void

--- a/nestkernel/recording_backend_sionlib.cpp
+++ b/nestkernel/recording_backend_sionlib.cpp
@@ -629,17 +629,18 @@ nest::RecordingBackendSIONlib::Parameters_::set( const RecordingBackendSIONlib&,
   d.update_value( names::sion_chunksize, sion_chunksize_ );
   d.update_value( names::sion_collective, sion_collective_ );
   long sion_n_files_long = sion_n_files_;
-  if (  d.update_value( names::sion_n_files, sion_n_files_long ) )
+  if ( d.update_value( names::sion_n_files, sion_n_files_long ) )
   {
-    if ( sion_n_files_long < 1 ) 
-  {
-    throw BadProperty("sion_n_files >= 1 required.");
-  }
-    if ( sion_n_files_long > std::numeric_limits<int>::max() )
-  {
-    throw BadProperty(String::compose("sion_n_files <= %1 required", std::to_string(std::numeric_limits<int>::max())));
-  }
-    sion_n_files_ = static_cast<int>(sion_n_files_long);
+    if ( sion_n_files_long < 1 )
+    {
+      throw BadProperty( "sion_n_files >= 1 required." );
+    }
+    if ( sion_n_files_long > std::numeric_limits< int >::max() )
+    {
+      throw BadProperty(
+        String::compose( "sion_n_files <= %1 required", std::to_string( std::numeric_limits< int >::max() ) ) );
+    }
+    sion_n_files_ = static_cast< int >( sion_n_files_long );
   }
 }
 

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -101,9 +101,10 @@ nest::RecordingDevice::State_::State_()
 void
 nest::RecordingDevice::State_::get( Dictionary& d ) const
 {
-  size_t n_events = 0;
+  long n_events = 0;
   d.update_value( names::n_events, n_events );
-  d[ names::n_events ] = n_events + n_events_;
+  assert( n_events >= 0 );
+  d[ names::n_events ] = static_cast< long >( n_events + n_events_ );
 }
 
 void

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -456,7 +456,7 @@ nest::SimulationManager::get_status( Dictionary& d )
   d[ names::ms_per_tic ] = Time::get_ms_per_tic();
   d[ names::tics_per_ms ] = Time::get_tics_per_ms();
   d[ names::tics_per_step ] =
-    static_cast< size_t >( Time::get_tics_per_step() ); // casting to avoid extra checks of any types
+    static_cast< long >( Time::get_tics_per_step() ); // casting to avoid extra checks of any types
   d[ names::resolution ] = Time::get_resolution().get_ms();
 
   d[ names::T_min ] = Time::min().get_ms();
@@ -472,7 +472,7 @@ nest::SimulationManager::get_status( Dictionary& d )
   d[ names::wfr_comm_interval ] = wfr_comm_interval_;
   d[ names::wfr_tol ] = wfr_tol_;
   d[ names::wfr_max_iterations ] = wfr_max_iterations_;
-  d[ names::wfr_interpolation_order ] = wfr_interpolation_order_;
+  d[ names::wfr_interpolation_order ] = static_cast< long >( wfr_interpolation_order_ );
 
   d[ names::update_time_limit ] = update_time_limit_;
   d[ names::min_update_time ] = min_update_time_;

--- a/nestkernel/sonata_connector.cpp
+++ b/nestkernel/sonata_connector.cpp
@@ -547,7 +547,7 @@ SonataConnector::create_edge_type_id_2_syn_spec_( Dictionary edge_params )
   for ( const auto& [ syn_k, syn_v ] : edge_params )
   {
     const int type_id = std::stoi( syn_k );
-    auto d = std::get< Dictionary >( syn_kv_pair.second.item );
+    const auto& d = std::get< Dictionary >( syn_v.item );
 
     const auto& syn_name = d.get< std::string >( "synapse_model" );
 

--- a/nestkernel/sp_manager.h
+++ b/nestkernel/sp_manager.h
@@ -210,7 +210,7 @@ private:
 inline GrowthCurve*
 SPManager::new_growth_curve( std::string name )
 {
-  const int nc_id = growthcurvedict_.get< long >( name );
+  const long nc_id = growthcurvedict_.get< long >( name );
   return growthcurve_factories_.at( nc_id )->create();
 }
 

--- a/nestkernel/sp_manager.h
+++ b/nestkernel/sp_manager.h
@@ -210,7 +210,7 @@ private:
 inline GrowthCurve*
 SPManager::new_growth_curve( std::string name )
 {
-  const int nc_id = growthcurvedict_.get< int >( name );
+  const int nc_id = growthcurvedict_.get< long >( name );
   return growthcurve_factories_.at( nc_id )->create();
 }
 

--- a/nestkernel/sp_manager_impl.h
+++ b/nestkernel/sp_manager_impl.h
@@ -44,7 +44,7 @@ SPManager::register_growth_curve( const std::string& name )
   assert( nc );
   const int id = growthcurve_factories_.size();
   growthcurve_factories_.push_back( nc );
-  growthcurvedict_[ name ] = id;
+  growthcurvedict_[ name ] = static_cast< long >( id );
 }
 
 } // namespace nest

--- a/nestkernel/target_identifier.h
+++ b/nestkernel/target_identifier.h
@@ -65,8 +65,8 @@ public:
     // Do nothing if called on synapse prototype
     if ( target_ )
     {
-      d[ names::rport ] = rport_;
-      d[ names::target ] = target_->get_node_id();
+      d[ names::rport ] = static_cast< long >( rport_ );
+      d[ names::target ] = static_cast< long >( target_->get_node_id() );
     }
   }
 

--- a/nestkernel/vp_manager.cpp
+++ b/nestkernel/vp_manager.cpp
@@ -177,8 +177,8 @@ nest::VPManager::set_status( const Dictionary& d )
 void
 nest::VPManager::get_status( Dictionary& d )
 {
-  d[ names::local_num_threads ] = get_num_threads();
-  d[ names::total_num_virtual_procs ] = get_num_virtual_processes();
+  d[ names::local_num_threads ] = static_cast< long >( get_num_threads() );
+  d[ names::total_num_virtual_procs ] = static_cast< long >( get_num_virtual_processes() );
 }
 
 void

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -496,7 +496,7 @@ def get_parameters_hierarchical_addressing(nc, params):
     # or list of strings.
     if isinstance(params[0], str):
         value_list = nc.get(params[0])
-        if not isinstance(value_list, tuple):
+        if not isinstance(value_list, (tuple, list)):
             value_list = (value_list,)
     else:
         raise TypeError("First argument must be a string, specifying path into hierarchical dictionary")

--- a/pynest/nestkernel_api.pxd
+++ b/pynest/nestkernel_api.pxd
@@ -62,6 +62,7 @@ cdef extern from "dictionary.h" namespace "std":
     T get[T](any_type& operand)
     cbool holds_alternative[T](const any_type&)
 
+
 cdef extern from "dictionary.h":
     cppclass Dictionary:
         Dictionary()

--- a/pynest/nestkernel_api.pxd
+++ b/pynest/nestkernel_api.pxd
@@ -61,6 +61,7 @@ cdef extern from "dictionary.h":
 cdef extern from "dictionary.h" namespace "std":
     T get[T](any_type& operand)
     cbool holds_alternative[T](const any_type&)
+    struct monostate
 
 
 cdef extern from "dictionary.h":
@@ -72,6 +73,9 @@ cdef extern from "dictionary.h":
         cbool known(const string&)
     string debug_type(const any_type&)
     string debug_dict_types(const Dictionary&)
+    cppclass AnyVector:
+        vector[any_type].const_iterator begin()
+        vector[any_type].const_iterator end()
 
 
 cdef extern from "logging.h" namespace "nest":

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -120,6 +120,14 @@ cdef object vec_of_dict_to_list(vector[Dictionary] cvec):
     return tmp
 
 
+cdef object vec_of_vec_of_dict_to_list(vector[vector[Dictionary]] cvec):
+    cdef tmp = []
+    cdef vector[vector[Dictionary]].iterator it = cvec.begin()
+    while it != cvec.end():
+        tmp.append(vec_of_dict_to_list(deref(it)))
+        inc(it)
+    return tmp
+
 def make_tuple_or_ndarray(operand):
         if len(operand) > 0 and isinstance(operand[0], numbers.Number):
             return numpy.array(operand)
@@ -140,58 +148,71 @@ cdef object dictionary_to_pydict(Dictionary cdict):
     return tmp
 
 cdef object any_to_pyobj(any_type operand):
-    if holds_alternative[int](operand):
-        return get[int](operand)
-    #if holds_alternative[uint](operand):
-    #    return get[uint](operand)
+    cdef NodeCollectionPTR ncptr
+
     if holds_alternative[long](operand):
         return get[long](operand)
-    #if holds_alternative[size_t](operand):
-    #    return get[size_t](operand)
-    #if holds_alternative[uint64_t](operand):
-    #    return get[uint64_t](operand)
-    #if holds_alternative[int64_t](operand):
-    #    return get[int64_t](operand)
     if holds_alternative[double](operand):
         return get[double](operand)
     if holds_alternative[cbool](operand):
         return get[cbool](operand)
     if holds_alternative[string](operand):
         return string_to_pystr(get[string](operand))
-    if holds_alternative[vector[int]](operand):
-        return numpy.array(get[vector[int]](operand))
+
     if holds_alternative[vector[long]](operand):
         return numpy.array(get[vector[long]](operand))
+    if holds_alternative[vector[vector[long]]](operand):
+        return numpy.array(get[vector[vector[long]]](operand))
+    if holds_alternative[vector[vector[vector[long]]]](operand):
+        return numpy.array(get[vector[vector[vector[long]]]](operand))
+    if holds_alternative[vector[vector[vector[vector[long]]]]](operand):
+        return numpy.array(get[vector[vector[vector[vector[long]]]]](operand))
+
     if holds_alternative[vector[cbool]](operand):
         return numpy.array(get[vector[cbool]](operand))
-    #if holds_alternative[vector[size_t]](operand):
-    #    return numpy.array(get[vector[size_t]](operand))
+
     if holds_alternative[vector[double]](operand):
         return numpy.array(get[vector[double]](operand))
     if holds_alternative[vector[vector[double]]](operand):
         return numpy.array(get[vector[vector[double]]](operand))
     if holds_alternative[vector[vector[vector[double]]]](operand):
         return numpy.array(get[vector[vector[vector[double]]]](operand))
-    if holds_alternative[vector[vector[vector[long]]]](operand):
-        return numpy.array(get[vector[vector[vector[long]]]](operand))
+    if holds_alternative[vector[vector[vector[vector[double]]]]](operand):
+        return numpy.array(get[vector[vector[vector[vector[double]]]]](operand))
+
     if holds_alternative[vector[string]](operand):
-        # PYNEST-NG: Do we want to have this or are bytestrings fine?
-        # return get[vector[string]](operand)
-        return list(map(lambda x: x.decode("utf-8"), get[vector[string]](operand)))
-    if holds_alternative[vector[Dictionary]](operand):
-        return vec_of_dict_to_list(get[vector[Dictionary]](operand))
-    if holds_alternative[EmptyList](operand):
-        # PYNEST-NG: This will create a Python list first and then convert to
-        # either tuple or numpy array, which will copy the data element-wise.
-        return make_tuple_or_ndarray(any_vector_to_list(get[EmptyList](operand)))
+        return [s.decode("utf-8") for s in get[vector[string]](operand)]
+    if holds_alternative[vector[vector[string]]](operand):
+        return [[s.decode("utf-8") for s in vs]
+                for vs in get[vector[vector[string]]](operand)]
+
     if holds_alternative[Dictionary](operand):
         return dictionary_to_pydict(get[Dictionary](operand))
+    if holds_alternative[vector[Dictionary]](operand):
+        return vec_of_dict_to_list(get[vector[Dictionary]](operand))
+    if holds_alternative[vector[vector[Dictionary]]](operand):
+        return vec_of_vec_of_dict_to_list(get[vector[vector[Dictionary]]](operand))
+
+    if holds_alternative[EmptyList](operand):
+        assert False, "Should never get an EmptyList from C++"
+        return None
+
     if holds_alternative[NodeCollectionPTR](operand):
         obj = NodeCollectionObject()
         obj._set_nc(get[NodeCollectionPTR](operand))
         return nest.NodeCollection(obj)
+    if holds_alternative[vector[NodeCollectionPTR]](operand):
+        res = []
+        for ncptr in get[vector[NodeCollectionPTR]](operand):
+            obj = NodeCollectionObject()
+            obj._set_nc(ncptr)
+            res.append(nest.NodeCollection(obj))
+        return res
+
     if holds_alternative[VerbosityLevel](operand):
         return get[VerbosityLevel](operand)
+
+    assert False, f"Operand: ]{debug_type(operand)}["
 
 
 cdef is_list_tuple_ndarray_of_float(v):

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -911,20 +911,20 @@ def llapi_connect_arrays(sources, targets, weights, delays, synapse_model, syn_p
             raise ValueError('syn_param_values must be a matrix with arrays of the same length as sources and targets.')
 
     # Get pointers to the first element in each NumPy array
-    cdef long[::1] sources_mv = numpy.ascontiguousarray(sources, dtype=numpy.int64)
-    cdef long* sources_ptr = &sources_mv[0]
+    cdef const long[::1] sources_mv = numpy.ascontiguousarray(sources, dtype=numpy.int64)
+    cdef const long* sources_ptr = &sources_mv[0]
 
-    cdef long[::1] targets_mv = numpy.ascontiguousarray(targets, dtype=numpy.int64)
-    cdef long* targets_ptr = &targets_mv[0]
+    cdef const long[::1] targets_mv = numpy.ascontiguousarray(targets, dtype=numpy.int64)
+    cdef const long* targets_ptr = &targets_mv[0]
 
-    cdef double[::1] weights_mv
-    cdef double* weights_ptr = NULL
+    cdef const double[::1] weights_mv
+    cdef const double* weights_ptr = NULL
     if weights is not None:
         weights_mv = numpy.ascontiguousarray(weights, dtype=numpy.double)
         weights_ptr = &weights_mv[0]
 
-    cdef double[::1] delays_mv
-    cdef double* delays_ptr = NULL
+    cdef const double[::1] delays_mv
+    cdef const double* delays_ptr = NULL
     if delays is not None:
         delays_mv = numpy.ascontiguousarray(delays, dtype=numpy.double)
         delays_ptr = &delays_mv[0]
@@ -935,8 +935,8 @@ def llapi_connect_arrays(sources, targets, weights, delays, synapse_model, syn_p
         for key in syn_param_keys:
             param_keys_ptr.push_back(pystr_to_string(key))
 
-    cdef double[:, ::1] param_values_mv
-    cdef double* param_values_ptr = NULL
+    cdef const double[:, ::1] param_values_mv
+    cdef const double* param_values_ptr = NULL
     if syn_param_values is not None:
         param_values_mv = numpy.ascontiguousarray(syn_param_values, dtype=numpy.double)
         param_values_ptr = &param_values_mv[0][0]

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -147,6 +147,15 @@ cdef object dictionary_to_pydict(Dictionary cdict):
         inc(it)
     return tmp
 
+cdef anyvec_to_objtuple(any_type operand):
+    cdef AnyVector a_vec = get[AnyVector](operand)
+    cdef tmp = []
+    cdef vector[any_type].const_iterator it = a_vec.begin()
+    while it != a_vec.end():
+        tmp.append(any_to_pyobj(deref(it)))
+        inc(it)
+    return tmp
+
 cdef object any_to_pyobj(any_type operand):
     cdef NodeCollectionPTR ncptr
 
@@ -208,6 +217,10 @@ cdef object any_to_pyobj(any_type operand):
             obj._set_nc(ncptr)
             res.append(nest.NodeCollection(obj))
         return res
+    if holds_alternative[monostate](operand):
+        return None
+    if holds_alternative[AnyVector](operand):
+        return anyvec_to_objtuple(operand)
 
     if holds_alternative[VerbosityLevel](operand):
         return get[VerbosityLevel](operand)

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -149,12 +149,7 @@ cdef object dictionary_to_pydict(Dictionary cdict):
 
 cdef anyvec_to_objtuple(any_type operand):
     cdef AnyVector a_vec = get[AnyVector](operand)
-    cdef tmp = []
-    cdef vector[any_type].const_iterator it = a_vec.begin()
-    while it != a_vec.end():
-        tmp.append(any_to_pyobj(deref(it)))
-        inc(it)
-    return tmp
+    return tuple(any_to_pyobj(obj) for obj in a_vec)
 
 cdef object any_to_pyobj(any_type operand):
     cdef NodeCollectionPTR ncptr

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -616,11 +616,11 @@ def llapi_copy_model(oldmodname, newmodname, object params):
 def llapi_get_nc_status(NodeCollectionObject nc, object key=None):
     statuses = dictionary_to_pydict( get_nc_status(nc.thisptr) )
     if key is None:
-        return statuses #dictionary_to_pydict(statuses)
+        return statuses
     elif isinstance(key, str):
-        if key not in statuses:    #.known(pystr_to_string(key)):
+        if key not in statuses:
             raise KeyError(key)
-        value = statuses[key]  #pystr_to_string(key)])
+        value = statuses[key]
         # PYNEST-NG-FUTURE: This is backwards-compatible, but makes it harder
         # to write scalable code. Maybe just return value as is?
         return value[0] if len(value) == 1 else value

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -107,10 +107,6 @@ cdef class MaskObject:
         self.thisptr = mask_ptr
 
 
-cdef object any_vector_to_list(EmptyList cvec):
-    return []
-
-
 cdef object vec_of_dict_to_list(vector[Dictionary] cvec):
     cdef tmp = []
     cdef vector[Dictionary].iterator it = cvec.begin()
@@ -169,8 +165,6 @@ cdef object any_to_pyobj(any_type operand):
         return numpy.array(get[vector[vector[long]]](operand))
     if holds_alternative[vector[vector[vector[long]]]](operand):
         return numpy.array(get[vector[vector[vector[long]]]](operand))
-    if holds_alternative[vector[vector[vector[vector[long]]]]](operand):
-        return numpy.array(get[vector[vector[vector[vector[long]]]]](operand))
 
     if holds_alternative[vector[cbool]](operand):
         return numpy.array(get[vector[cbool]](operand))
@@ -181,8 +175,6 @@ cdef object any_to_pyobj(any_type operand):
         return numpy.array(get[vector[vector[double]]](operand))
     if holds_alternative[vector[vector[vector[double]]]](operand):
         return numpy.array(get[vector[vector[vector[double]]]](operand))
-    if holds_alternative[vector[vector[vector[vector[double]]]]](operand):
-        return numpy.array(get[vector[vector[vector[vector[double]]]]](operand))
 
     if holds_alternative[vector[string]](operand):
         return [s.decode("utf-8") for s in get[vector[string]](operand)]
@@ -205,6 +197,7 @@ cdef object any_to_pyobj(any_type operand):
         obj = NodeCollectionObject()
         obj._set_nc(get[NodeCollectionPTR](operand))
         return nest.NodeCollection(obj)
+
     if holds_alternative[vector[NodeCollectionPTR]](operand):
         res = []
         for ncptr in get[vector[NodeCollectionPTR]](operand):
@@ -212,15 +205,21 @@ cdef object any_to_pyobj(any_type operand):
             obj._set_nc(ncptr)
             res.append(nest.NodeCollection(obj))
         return res
+
+    # This monostate represents missing NodeCollection status data (nodes on other ranks)
+    # Translates to None for NEST 3.9 compatibility
     if holds_alternative[monostate](operand):
         return None
+
+    # get_nc_status() returns a vector<any_type> for NEST 3.9 compatibility
+    # This alternative starts the unpacking of that vector into a tuple
     if holds_alternative[AnyVector](operand):
         return anyvec_to_objtuple(operand)
 
     if holds_alternative[VerbosityLevel](operand):
         return get[VerbosityLevel](operand)
 
-    assert False, f"Operand: ]{debug_type(operand)}["
+    raise RuntimeError(f"Cannot convert value of type '{debug_type(operand)}' returned by NEST kernel to Python object.")
 
 
 cdef is_list_tuple_ndarray_of_float(v):
@@ -615,7 +614,6 @@ def llapi_copy_model(oldmodname, newmodname, object params):
 
 
 def llapi_get_nc_status(NodeCollectionObject nc, object key=None):
-    #cdef Dictionary statuses = get_nc_status(nc.thisptr)
     statuses = dictionary_to_pydict( get_nc_status(nc.thisptr) )
     if key is None:
         return statuses #dictionary_to_pydict(statuses)

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -142,16 +142,16 @@ cdef object dictionary_to_pydict(Dictionary cdict):
 cdef object any_to_pyobj(any_type operand):
     if holds_alternative[int](operand):
         return get[int](operand)
-    if holds_alternative[uint](operand):
-        return get[uint](operand)
+    #if holds_alternative[uint](operand):
+    #    return get[uint](operand)
     if holds_alternative[long](operand):
         return get[long](operand)
-    if holds_alternative[size_t](operand):
-        return get[size_t](operand)
-    if holds_alternative[uint64_t](operand):
-        return get[uint64_t](operand)
-    if holds_alternative[int64_t](operand):
-        return get[int64_t](operand)
+    #if holds_alternative[size_t](operand):
+    #    return get[size_t](operand)
+    #if holds_alternative[uint64_t](operand):
+    #    return get[uint64_t](operand)
+    #if holds_alternative[int64_t](operand):
+    #    return get[int64_t](operand)
     if holds_alternative[double](operand):
         return get[double](operand)
     if holds_alternative[cbool](operand):
@@ -162,8 +162,10 @@ cdef object any_to_pyobj(any_type operand):
         return numpy.array(get[vector[int]](operand))
     if holds_alternative[vector[long]](operand):
         return numpy.array(get[vector[long]](operand))
-    if holds_alternative[vector[size_t]](operand):
-        return numpy.array(get[vector[size_t]](operand))
+    if holds_alternative[vector[cbool]](operand):
+        return numpy.array(get[vector[cbool]](operand))
+    #if holds_alternative[vector[size_t]](operand):
+    #    return numpy.array(get[vector[size_t]](operand))
     if holds_alternative[vector[double]](operand):
         return numpy.array(get[vector[double]](operand))
     if holds_alternative[vector[vector[double]]](operand):
@@ -584,13 +586,14 @@ def llapi_copy_model(oldmodname, newmodname, object params):
 
 
 def llapi_get_nc_status(NodeCollectionObject nc, object key=None):
-    cdef Dictionary statuses = get_nc_status(nc.thisptr)
+    #cdef Dictionary statuses = get_nc_status(nc.thisptr)
+    statuses = dictionary_to_pydict( get_nc_status(nc.thisptr) )
     if key is None:
-        return dictionary_to_pydict(statuses)
+        return statuses #dictionary_to_pydict(statuses)
     elif isinstance(key, str):
-        if not statuses.known(pystr_to_string(key)):
+        if key not in statuses:    #.known(pystr_to_string(key)):
             raise KeyError(key)
-        value = any_to_pyobj(statuses[pystr_to_string(key)])
+        value = statuses[key]  #pystr_to_string(key)])
         # PYNEST-NG-FUTURE: This is backwards-compatible, but makes it harder
         # to write scalable code. Maybe just return value as is?
         return value[0] if len(value) == 1 else value

--- a/testsuite/pytests/sli2py_regressions/test_issue_708.py
+++ b/testsuite/pytests/sli2py_regressions/test_issue_708.py
@@ -59,7 +59,7 @@ def test_copymodel_with_secondary_events():
     nest.Simulate(10.0)
 
     # Check that both neurons have become depolarized due to input from neuron_in
-    assert all(neurons_out.V_m > V_m_ini)
+    assert all(Vm_out > Vm_ini for Vm_out, Vm_ini in zip(neurons_out.V_m, V_m_ini))
 
     # Check stronger effect on second neuron due to larger weight
     assert neurons_out[1].V_m > neurons_out[0].V_m

--- a/testsuite/pytests/test_connect_arrays.py
+++ b/testsuite/pytests/test_connect_arrays.py
@@ -23,6 +23,7 @@ import unittest
 
 import nest
 import numpy as np
+import pandas as pd
 
 nest.verbosity = nest.VerbosityLevel.WARNING
 
@@ -389,6 +390,18 @@ class TestConnectArrays(unittest.TestCase):
         src_alpha = {key: val for key, val in zip(src, alp)}
 
         self.assertEqual(src_alpha_ref, src_alpha)
+
+    def test_connect_arrays_pandas(self):
+        """
+        Confirm that data from pandas data frames can be passed.
+        """
+
+        n_nrn = 50
+        n = nest.Create("parrot_neuron", n=n_nrn)
+        df = pd.DataFrame.from_dict({"s": np.array(n), "t": np.array(n), "w": np.linspace(0, 10, num=n_nrn)})
+
+        # This failed with "ValueError: buffer source array is read-only" previously
+        nest.Connect(df.s.values, df.t.values, "one_to_one", {"weight": df.w.values})
 
 
 def suite():

--- a/testsuite/pytests/test_create.py
+++ b/testsuite/pytests/test_create.py
@@ -77,7 +77,7 @@ def test_create_with_params_dict():
     voltage = 12.0
     nodes = nest.Create("iaf_psc_alpha", num_nodes, {"V_m": voltage})
 
-    nptest.assert_equal(nodes.V_m, voltage)
+    assert nodes.V_m == (voltage,) * num_nodes
 
 
 def test_create_accepts_empty_params_dict():

--- a/testsuite/pytests/test_node_collection_get.py
+++ b/testsuite/pytests/test_node_collection_get.py
@@ -50,8 +50,9 @@ def reset():
 def test_node_collection_get_neuron_params(neuron_param, expected_value):
     """Test ``get`` on neuron parameters."""
 
-    nodes = nest.Create("iaf_psc_alpha", 10)
-    nptest.assert_equal(nodes.get(neuron_param), expected_value)
+    n_neurons = 10
+    nodes = nest.Create("iaf_psc_alpha", n_neurons)
+    nodes.get(neuron_param) == [expected_value] * n_neurons
 
 
 def test_node_collection_get_node_ids():
@@ -69,16 +70,9 @@ def test_node_collection_get_multiple_params():
 
     g = nodes.get(["local", "thread", "vp"])
 
-    g_reference = {
-        "local": np.full((num_nodes), True),
-        "thread": np.zeros(num_nodes, dtype=int),
-        "vp": np.zeros(num_nodes, dtype=int),
-    }
+    g_reference = {"local": (True,) * num_nodes, "thread": (0,) * num_nodes, "vp": (0,) * num_nodes}
 
-    nptest.assert_equal(g["local"], True)
-    nptest.assert_equal(g["thread"], 0)
-    nptest.assert_equal(g["vp"], 0)
-    nptest.assert_equal(g, g_reference)
+    assert g == g_reference
 
 
 @pytest.mark.parametrize(
@@ -93,8 +87,9 @@ def test_node_collection_get_multiple_params():
 def test_node_collection_get_attribute(neuron_param, expected_value):
     """Test the ``__getattr__`` method."""
 
-    nodes = nest.Create("iaf_psc_alpha", 10)
-    nptest.assert_equal(getattr(nodes, neuron_param), expected_value)
+    n_neurons = 10
+    nodes = nest.Create("iaf_psc_alpha", n_neurons)
+    assert getattr(nodes, neuron_param) == (expected_value,) * n_neurons
 
 
 def test_node_collection_get_nonexistent_attribute_raises():
@@ -234,7 +229,7 @@ def test_different_sized_node_collections_get():
 
     # Multiple nodes, no parameter (gets all values)
     multi_full_dict = multi_sr.get()
-    nptest.assert_equal(multi_full_dict["start"], 0.0)
+    multi_full_dict["start"] == [0.0] * len(multi_sr)
 
     # Ensure that single and multiple gets have the same number of params
     single_num_params = len(single_full_dict.keys())

--- a/testsuite/pytests/test_node_collection_set.py
+++ b/testsuite/pytests/test_node_collection_set.py
@@ -36,10 +36,11 @@ def reset():
 def test_node_collection_set_single_param():
     """Test ``set`` with a single parameter."""
 
-    nodes = nest.Create("iaf_psc_alpha", 10)
+    num_nodes = 10
+    nodes = nest.Create("iaf_psc_alpha", num_nodes)
     nodes.set(tau_Ca=500.0)
 
-    nptest.assert_equal(nodes.tau_Ca, 500.0)
+    assert nodes.tau_Ca == (500.0,) * num_nodes
 
 
 def test_node_collection_set_list_of_single_param():
@@ -64,10 +65,11 @@ def test_node_collection_set_list_of_single_param_wrong_length_raises():
 def test_node_collection_set_dict_single_param():
     """Test ``set`` with dictionary containing a single parameter."""
 
-    nodes = nest.Create("iaf_psc_alpha", 10)
+    num_nodes = 10
+    nodes = nest.Create("iaf_psc_alpha", num_nodes)
     nodes.set({"C_m": 100.0})
 
-    nptest.assert_equal(nodes.C_m, 100.0)
+    assert nodes.C_m == (100.0,) * num_nodes
 
 
 def test_node_collection_set_list_of_dicts():
@@ -94,25 +96,27 @@ def test_node_collection_set_list_of_dicts():
 def test_node_collection_set_dict_multiple_params():
     """Test ``set`` with dictionary containing multiple parameters."""
 
-    nodes = nest.Create("iaf_psc_alpha", 10)
+    num_nodes = 10
+    nodes = nest.Create("iaf_psc_alpha", num_nodes)
     nodes.set({"t_ref": 44.0, "tau_m": 2.0, "tau_minus": 42.0})
 
-    nptest.assert_equal(nodes.t_ref, 44.0)
-    nptest.assert_equal(nodes.tau_m, 2.0)
-    nptest.assert_equal(nodes.tau_minus, 42.0)
+    assert nodes.t_ref == (44.0,) * num_nodes
+    assert nodes.tau_m == (2.0,) * num_nodes
+    assert nodes.tau_minus == (42.0,) * num_nodes
 
 
 def test_node_collection_set_dict_with_lists():
     """Test ``set`` with dictionary containing multiple parameter lists."""
 
-    nodes = nest.Create("iaf_psc_alpha", 3)
+    num_nodes = 3
+    nodes = nest.Create("iaf_psc_alpha", num_nodes)
     Vm_ref = [-11.0, -12.0, -13.0]
     Cm_ref = 177.0
     tau_minus_ref = [22.0, 24.0, 26.0]
     nodes.set({"V_m": Vm_ref, "C_m": Cm_ref, "tau_minus": tau_minus_ref})
 
     nptest.assert_array_equal(nodes.V_m, Vm_ref)
-    nptest.assert_equal(nodes.C_m, Cm_ref)
+    assert nodes.C_m == (177.0,) * num_nodes
     nptest.assert_array_equal(nodes.tau_minus, tau_minus_ref)
 
 
@@ -207,13 +211,14 @@ def test_sliced_node_collection_set():
 def test_node_collection_set_attribute():
     """Test the ``__setattr__`` method."""
 
-    nodes = nest.Create("iaf_psc_alpha", 10)
+    num_nodes = 10
+    nodes = nest.Create("iaf_psc_alpha", num_nodes)
     V_reset_ref = [-85.0, -82.0, -80.0, -77.0, -75.0, -72.0, -70.0, -67.0, -65.0, -62.0]
 
     nodes.C_m = 100.0
     nodes.V_reset = V_reset_ref
 
-    nptest.assert_equal(nodes.C_m, 100.0)
+    assert nodes.C_m == (100.0,) * num_nodes
     nptest.assert_array_equal(nodes.V_reset, V_reset_ref)
 
 

--- a/testsuite/pytests/test_spatial/test_layer_get_set.py
+++ b/testsuite/pytests/test_spatial/test_layer_get_set.py
@@ -23,6 +23,8 @@
 Tests for ``get`` and ``set`` functions for spatial ``NodeCollection``.
 """
 
+import math
+
 import nest
 import numpy.testing as nptest
 import pytest
@@ -90,9 +92,11 @@ def test_layer_set_nonexistent_param_raises():
 
 def test_layer_get_node_param():
     """Test ``get`` on layered ``NodeCollection`` node parameter."""
-    layer = nest.Create("iaf_psc_alpha", positions=nest.spatial.grid(shape=[2, 2]))
 
-    nptest.assert_equal(layer.get("V_m"), -70.0)
+    shape = [2, 2]
+    layer = nest.Create("iaf_psc_alpha", positions=nest.spatial.grid(shape=shape))
+
+    assert layer.get("V_m") == (-70.0,) * math.prod(shape)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@JanVogelsang This PR against your variants branch now passes all tests, at least on my machine (Github verdict is pending). I reverted the return values to Python now to strict NEST 3.9 compatibility, so that when getting the status of a NodeCollection, the data from the individual nodes are combined in a tuple and non-local nodes are represented by `None`.

