### PR TITLE
Partially fix Dictionary comparison

### DIFF
--- a/libnestutil/dict_util.h
+++ b/libnestutil/dict_util.h
@@ -43,7 +43,7 @@ update_value_param( Dictionary const& d, const std::string& key, T& value, nest:
 {
   assert( node != nullptr );
   const auto it = d.find( key );
-  if ( it != d.end() and is_type< std::shared_ptr< nest::Parameter > >( it->second.item ) )
+  if ( it != d.end() and std::holds_alternative< std::shared_ptr< nest::Parameter > >( it->second.item ) )
   {
     const auto param = d.get< ParameterPTR >( key );
     const auto vp = kernel().vp_manager.node_id_to_vp( node->get_node_id() );

--- a/libnestutil/dictionary.cpp
+++ b/libnestutil/dictionary.cpp
@@ -260,46 +260,6 @@ operator<<( std::ostream& os, const AnyVector& av )
 }
 
 
-/**
- * Return true only if first and second both hold type T and compare equal as T.
- */
-template < typename T >
-bool
-equal_as_( const any_type& first, const any_type& second )
-{
-  // Compiler will short-circuit to false if not same type
-  return is_type< T >( first ) and is_type< T >( second ) and std::get< T >( first ) == std::get< T >( second );
-}
-
-bool
-value_equal( const any_type& first, const any_type& second )
-{
-  // helper to provide error in case we forgot a type in the equal_as_ chain.
-  auto fail = []( const any_type& first, const any_type& second )
-  {
-    throw std::runtime_error(
-      String::compose( "Fail to compare: left '%1', right '%2'", debug_type( first ), debug_type( second ) ) );
-    return false;
-  };
-
-  // Short-circuits as soon as an equal_as_() call evaluates to true
-  // clang-format off
-  return (
-     equal_as_< long >( first, second )
-    or equal_as_< double >( first, second )
-    or equal_as_< bool >( first, second )
-    or equal_as_< std::string >( first, second )
-    or equal_as_< std::vector< long > >( first, second )
-    or equal_as_< std::vector< double > >( first, second )
-    or equal_as_< std::vector< std::string > >( first, second )
-    or equal_as_< std::vector< std::vector< double > > >( first, second )
-    or equal_as_< Dictionary >( first, second )
-    or equal_as_< std::shared_ptr< nest::Parameter > >( first, second )
-    or fail( first, second )
-  );
-  // clang-format on
-}
-
 bool
 dictionary_::operator==( const dictionary_& other ) const
 {
@@ -307,22 +267,26 @@ dictionary_::operator==( const dictionary_& other ) const
   {
     return false;
   }
+
   // Iterate elements in the other Dictionary
   for ( const auto& [ other_key, other_entry ] : other )
   {
     // Check if it exists in this Dictionary
+    // Because we know that both dicts have the same size, this suffices to
+    // to confirm that both dictionaries have the same keys.
     if ( not known( other_key ) )
     {
       return false;
     }
 
-    // Check for equality
+    // Check for equality using operator==() for variants
     const auto& this_entry = maptype_::at( other_key );
-    if ( not value_equal( this_entry.item, other_entry.item ) )
+    if ( this_entry != other_entry )
     {
       return false;
     }
   }
+
   // All elements are equal
   return true;
 }

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -68,20 +68,19 @@ struct DictionarySchemaBuilder
                                                      // non-local nodes in a node-colection
     Scalars...,                                      // scalar types
     std::vector< Scalars >...,                       // vector variants of the scalar types
-    std::vector< std::vector< Scalars > >...,        // vec-vec variants of the scalar types
-    std::vector< std::vector< std::vector< Scalars > > >...,  // vec-vec-vec variants of the scalar types (for
-                                                              // correlomatrix-detector)
-    Extras...                                                 // any extra types (see definition of any_type below)
+    Extras...                                        // any extra types (see definition of any_type below)
     >;
 };
 
-using DictionarySchema = DictionarySchemaBuilder< long, double, bool, std::string, Dictionary >;
+using DictionarySchema = DictionarySchemaBuilder< double, long, bool, std::string, Dictionary >;
 
 using any_type = DictionarySchema::VariantType< std::shared_ptr< nest::NodeCollection >,
-  std::vector< std::shared_ptr< nest::NodeCollection > >,
+  std::vector< std::vector< double > >,
+  std::vector< std::vector< std::vector< double > > >,
+  std::vector< std::vector< std::vector< long > > >,
   std::shared_ptr< nest::Parameter >,
-  nest::VerbosityLevel,
   AnyVector,  // this is only used to hold status data from elements of a node collection in a NEST 3.9 compatible way
+  nest::VerbosityLevel,
   EmptyList >;
 
 class AnyVector : public std::vector< any_type >
@@ -101,15 +100,7 @@ concept Integer = std::integral< T > and not std::same_as< T, bool > and not std
 
 // Define a concept that T must be holdable by any_type
 template < typename T >
-concept DictionaryType = std::is_constructible_v< any_type, T >;
-
-template < typename T >
-bool
-is_type( const any_type& operand )
-{
-  return std::holds_alternative< T >( operand );
-}
-
+concept DictionaryEntryType = std::is_constructible_v< any_type, T >;
 
 class Dictionary : public std::shared_ptr< dictionary_ >
 {
@@ -155,7 +146,7 @@ public:
   void
   all_entries_accessed( const std::string& where, const std::string& what, const bool thread_local_dict = false ) const;
 
-  template < DictionaryType T >
+  template < DictionaryEntryType T >
   T get( const std::string& key ) const;
 
   template < typename T >
@@ -169,12 +160,6 @@ public:
 
   bool update_dictionary( dictionary_& dict_out ) const;
 };
-
-namespace nest
-{
-class Parameter;
-class NodeCollection;
-}
 
 /**
  * @brief Get the typename of the operand.
@@ -302,7 +287,7 @@ public:
    * @throws TypeMismatch if the value is not of specified type T.
    * @return the value at key cast to the specified type.
    */
-  template < DictionaryType T >
+  template < DictionaryEntryType T >
   T
   get( const std::string& key ) const
   {
@@ -574,7 +559,7 @@ Dictionary::all_entries_accessed( const std::string& where,
   ( *this )->all_entries_accessed( where, what, thread_local_dict );
 }
 
-template < DictionaryType T >
+template < DictionaryEntryType T >
 inline T
 Dictionary::get( const std::string& key ) const
 {

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -121,7 +121,7 @@ nest::cm_default::set_status( const Dictionary& statusdict )
    */
   const auto add_compartments_list_or_dict = [ this, &statusdict ]( const std::string name )
   {
-    if ( is_type< std::vector< Dictionary > >( statusdict.at( name ) ) )
+    if ( std::holds_alternative< std::vector< Dictionary > >( statusdict.at( name ) ) )
     {
       const auto compartments = statusdict.get< std::vector< Dictionary > >( name );
       // A list of compartments is provided, we add them all to the tree
@@ -130,7 +130,7 @@ nest::cm_default::set_status( const Dictionary& statusdict )
         add_compartment_( compartment_dict );
       }
     }
-    else if ( is_type< Dictionary >( statusdict.at( name ) ) )
+    else if ( std::holds_alternative< Dictionary >( statusdict.at( name ) ) )
     {
       // A single compartment is provided, we add add it to the tree
       add_compartment_( statusdict.get< Dictionary >( name ) );
@@ -152,7 +152,7 @@ nest::cm_default::set_status( const Dictionary& statusdict )
    */
   const auto add_receptors_list_or_dict = [ this, &statusdict ]( const std::string name )
   {
-    if ( is_type< std::vector< Dictionary > >( statusdict.at( name ) ) )
+    if ( std::holds_alternative< std::vector< Dictionary > >( statusdict.at( name ) ) )
     {
       const auto receptors = statusdict.get< std::vector< Dictionary > >( name );
       for ( const auto& receptor_dict : receptors )
@@ -160,7 +160,7 @@ nest::cm_default::set_status( const Dictionary& statusdict )
         add_receptor_( receptor_dict );
       }
     }
-    else if ( is_type< Dictionary >( statusdict.at( name ) ) )
+    else if ( std::holds_alternative< Dictionary >( statusdict.at( name ) ) )
     {
       add_receptor_( statusdict.get< Dictionary >( name ) );
     }

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -75,11 +75,11 @@ nest::weight_recorder::Parameters_::set( const Dictionary& d )
     if ( d.known( key ) )
     {
       const auto value = d.at( key );
-      if ( is_type< NodeCollectionPTR >( value ) )
+      if ( std::holds_alternative< NodeCollectionPTR >( value ) )
       {
         nc = d.get< NodeCollectionPTR >( key );
       }
-      else if ( is_type< std::vector< long > >( value ) )
+      else if ( std::holds_alternative< std::vector< long > >( value ) )
       {
         const std::vector< long >& nodes_long = d.get< std::vector< long > >( key );
         std::vector< size_t > nodes_size_t;

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1401,7 +1401,7 @@ nest::FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
     throw BadProperty( "Source array must not be empty." );
   }
   auto indegree = conn_spec.at( names::indegree );
-  if ( is_type< std::shared_ptr< nest::Parameter > >( indegree ) )
+  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( indegree ) )
   {
     indegree_ = std::get< ParameterPTR >( indegree );
     // TODO: Checks of parameter range
@@ -1565,7 +1565,7 @@ nest::FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
     throw BadProperty( "Target array must not be empty." );
   }
   auto outdegree = conn_spec.at( names::outdegree );
-  if ( is_type< std::shared_ptr< nest::Parameter > >( outdegree ) )
+  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( outdegree ) )
   {
     outdegree_ = std::get< ParameterPTR >( outdegree );
     // TODO: Checks of parameter range
@@ -1858,7 +1858,7 @@ nest::BernoulliBuilder::BernoulliBuilder( NodeCollectionPTR sources,
   : BipartiteConnBuilder( sources, targets, third_out, conn_spec, syn_specs )
 {
   auto p = conn_spec.at( names::p );
-  if ( is_type< std::shared_ptr< nest::Parameter > >( p ) )
+  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( p ) )
   {
     p_ = std::get< ParameterPTR >( p );
     // TODO: Checks of parameter range
@@ -1974,7 +1974,7 @@ nest::PoissonBuilder::PoissonBuilder( NodeCollectionPTR sources,
 {
 
   auto p = conn_spec.at( names::pairwise_avg_num_conns );
-  if ( is_type< std::shared_ptr< nest::Parameter > >( p ) )
+  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( p ) )
   {
     pairwise_avg_num_conns_ = std::get< ParameterPTR >( p );
   }

--- a/nestkernel/conn_parameter.cpp
+++ b/nestkernel/conn_parameter.cpp
@@ -30,31 +30,31 @@ nest::ConnParameter*
 nest::ConnParameter::create( const any_type& value, const size_t nthreads )
 {
   // single double
-  if ( is_type< double >( value ) )
+  if ( std::holds_alternative< double >( value ) )
   {
     return new ScalarDoubleParameter( std::get< double >( value ), nthreads );
   }
 
   // single integer
-  if ( is_type< long >( value ) )
+  if ( std::holds_alternative< long >( value ) )
   {
     return new ScalarIntegerParameter( std::get< long >( value ), nthreads );
   }
 
   // array of doubles
-  if ( is_type< std::vector< double > >( value ) )
+  if ( std::holds_alternative< std::vector< double > >( value ) )
   {
     return new ArrayDoubleParameter( std::get< std::vector< double > >( value ), nthreads );
   }
 
   // Parameter
-  if ( is_type< std::shared_ptr< nest::Parameter > >( value ) )
+  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( value ) )
   {
     return new ParameterConnParameterWrapper( std::get< ParameterPTR >( value ), nthreads );
   }
 
   // array of longs
-  if ( is_type< std::vector< long > >( value ) )
+  if ( std::holds_alternative< std::vector< long > >( value ) )
   {
     return new ArrayLongParameter( std::get< std::vector< long > >( value ), nthreads );
   }

--- a/nestkernel/connection_creator.cpp
+++ b/nestkernel/connection_creator.cpp
@@ -49,7 +49,7 @@ ConnectionCreator::ConnectionCreator( const Dictionary& dict )
   // Need to store number of connections in a temporary variable to be able to detect negative values.
   if ( dict.known( names::number_of_connections ) )
   {
-    if ( is_type< ParameterPTR >( dict.at( names::number_of_connections ) ) )
+    if ( std::holds_alternative< ParameterPTR >( dict.at( names::number_of_connections ) ) )
     {
       dict.update_value< ParameterPTR >( names::number_of_connections, number_of_connections_ );
     }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -652,7 +652,7 @@ nest::ConnectionManager::connect_arrays( const long* sources,
       }
 
       // If the default value is an integer, the synapse parameter must also be an integer.
-      if ( is_type< long >( syn_model_default_it->second.item ) )
+      if ( std::holds_alternative< long >( syn_model_default_it->second.item ) )
       {
         param_pointers[ param_key ].second = true;
         param_dicts[ i ][ param_key ] = 0;

--- a/nestkernel/free_layer.h
+++ b/nestkernel/free_layer.h
@@ -136,7 +136,7 @@ FreeLayer< D >::set_status( const Dictionary& d )
   if ( d.known( names::positions ) )
   {
     const auto positions = d.at( names::positions );
-    if ( is_type< std::vector< std::vector< double > > >( positions ) )
+    if ( std::holds_alternative< std::vector< std::vector< double > > >( positions ) )
     {
       positions_.clear();
       positions_.reserve( num_local_nodes_ );
@@ -169,7 +169,7 @@ FreeLayer< D >::set_status( const Dictionary& d )
       }
       assert( positions_.size() == num_local_nodes_ );
     }
-    else if ( is_type< std::shared_ptr< nest::Parameter > >( positions ) )
+    else if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( positions ) )
     {
       auto pd = d.get< ParameterPTR >( names::positions );
       auto pos = dynamic_cast< DimensionParameter* >( pd.get() );

--- a/nestkernel/layer.cpp
+++ b/nestkernel/layer.cpp
@@ -66,13 +66,13 @@ AbstractLayer::create_layer( const Dictionary& layer_dict )
     int num_dimensions = 0;
 
     const auto positions = layer_dict.at( names::positions );
-    if ( is_type< std::vector< std::vector< double > > >( positions ) )
+    if ( std::holds_alternative< std::vector< std::vector< double > > >( positions ) )
     {
       const auto pos = layer_dict.get< std::vector< std::vector< double > > >( names::positions );
       length = pos.size();
       num_dimensions = pos[ 0 ].size();
     }
-    else if ( is_type< std::shared_ptr< nest::Parameter > >( positions ) )
+    else if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( positions ) )
     {
       auto pd = layer_dict.get< ParameterPTR >( names::positions );
       auto pos = dynamic_cast< DimensionParameter* >( pd.get() );

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -518,10 +518,10 @@ public:
    */
   size_t get_step_size() const;
 
-  friend std::ostream& operator<<( std::ostream& os, const nc_const_iterator& e );
+  friend std::ostream& operator<<( std::ostream& os, const nc_const_iterator& nci );
 };
 
-std::ostream& operator<<( std::ostream& os, const nc_const_iterator& e );
+std::ostream& operator<<( std::ostream& os, const nc_const_iterator& nci );
 
 
 /**

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -298,9 +298,6 @@ class NodeCollection:
         if not isinstance(other, NodeCollection):
             raise NotImplementedError("Cannot compare NodeCollection to {}".format(type(other).__name__))
 
-        if self.__len__() != other.__len__():
-            return False
-
         return nestkernel.llapi_eq_nc(self._datum, other._datum)
 
     def __neq__(self, other):

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -116,14 +116,6 @@ cdef object vec_of_dict_to_list(vector[Dictionary] cvec):
     return tmp
 
 
-cdef object vec_of_vec_of_dict_to_list(vector[vector[Dictionary]] cvec):
-    cdef tmp = []
-    cdef vector[vector[Dictionary]].iterator it = cvec.begin()
-    while it != cvec.end():
-        tmp.append(vec_of_dict_to_list(deref(it)))
-        inc(it)
-    return tmp
-
 def make_tuple_or_ndarray(operand):
         if len(operand) > 0 and isinstance(operand[0], numbers.Number):
             return numpy.array(operand)
@@ -178,17 +170,11 @@ cdef object any_to_pyobj(any_type operand):
 
     if holds_alternative[vector[string]](operand):
         return [s.decode("utf-8") for s in get[vector[string]](operand)]
-    #if holds_alternative[vector[vector[string]]](operand):
-    #    return [[s.decode("utf-8") for s in vs]
-    #            for vs in get[vector[vector[string]]](operand)]
 
     if holds_alternative[Dictionary](operand):
         return dictionary_to_pydict(get[Dictionary](operand))
     if holds_alternative[vector[Dictionary]](operand):
         return vec_of_dict_to_list(get[vector[Dictionary]](operand))
-    #if holds_alternative[vector[vector[Dictionary]]](operand):
-    #    return vec_of_vec_of_dict_to_list(get[vector[vector[Dictionary]]](operand))
-
     if holds_alternative[EmptyList](operand):
         assert False, "Should never get an EmptyList from C++"
         return None
@@ -197,14 +183,6 @@ cdef object any_to_pyobj(any_type operand):
         obj = NodeCollectionObject()
         obj._set_nc(get[NodeCollectionPTR](operand))
         return nest.NodeCollection(obj)
-
-    #if holds_alternative[vector[NodeCollectionPTR]](operand):
-    #    res = []
-    #    for ncptr in get[vector[NodeCollectionPTR]](operand):
-    #        obj = NodeCollectionObject()
-    #        obj._set_nc(ncptr)
-    #        res.append(nest.NodeCollection(obj))
-    #    return res
 
     # This monostate represents missing NodeCollection status data (nodes on other ranks)
     # Translates to None for NEST 3.9 compatibility

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -153,8 +153,6 @@ cdef object any_to_pyobj(any_type operand):
 
     if holds_alternative[vector[long]](operand):
         return numpy.array(get[vector[long]](operand))
-    #if holds_alternative[vector[vector[long]]](operand):
-    #    return numpy.array(get[vector[vector[long]]](operand))
     if holds_alternative[vector[vector[vector[long]]]](operand):
         return numpy.array(get[vector[vector[vector[long]]]](operand))
 

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -161,8 +161,8 @@ cdef object any_to_pyobj(any_type operand):
 
     if holds_alternative[vector[long]](operand):
         return numpy.array(get[vector[long]](operand))
-    if holds_alternative[vector[vector[long]]](operand):
-        return numpy.array(get[vector[vector[long]]](operand))
+    #if holds_alternative[vector[vector[long]]](operand):
+    #    return numpy.array(get[vector[vector[long]]](operand))
     if holds_alternative[vector[vector[vector[long]]]](operand):
         return numpy.array(get[vector[vector[vector[long]]]](operand))
 
@@ -178,16 +178,16 @@ cdef object any_to_pyobj(any_type operand):
 
     if holds_alternative[vector[string]](operand):
         return [s.decode("utf-8") for s in get[vector[string]](operand)]
-    if holds_alternative[vector[vector[string]]](operand):
-        return [[s.decode("utf-8") for s in vs]
-                for vs in get[vector[vector[string]]](operand)]
+    #if holds_alternative[vector[vector[string]]](operand):
+    #    return [[s.decode("utf-8") for s in vs]
+    #            for vs in get[vector[vector[string]]](operand)]
 
     if holds_alternative[Dictionary](operand):
         return dictionary_to_pydict(get[Dictionary](operand))
     if holds_alternative[vector[Dictionary]](operand):
         return vec_of_dict_to_list(get[vector[Dictionary]](operand))
-    if holds_alternative[vector[vector[Dictionary]]](operand):
-        return vec_of_vec_of_dict_to_list(get[vector[vector[Dictionary]]](operand))
+    #if holds_alternative[vector[vector[Dictionary]]](operand):
+    #    return vec_of_vec_of_dict_to_list(get[vector[vector[Dictionary]]](operand))
 
     if holds_alternative[EmptyList](operand):
         assert False, "Should never get an EmptyList from C++"
@@ -198,13 +198,13 @@ cdef object any_to_pyobj(any_type operand):
         obj._set_nc(get[NodeCollectionPTR](operand))
         return nest.NodeCollection(obj)
 
-    if holds_alternative[vector[NodeCollectionPTR]](operand):
-        res = []
-        for ncptr in get[vector[NodeCollectionPTR]](operand):
-            obj = NodeCollectionObject()
-            obj._set_nc(ncptr)
-            res.append(nest.NodeCollection(obj))
-        return res
+    #if holds_alternative[vector[NodeCollectionPTR]](operand):
+    #    res = []
+    #    for ncptr in get[vector[NodeCollectionPTR]](operand):
+    #        obj = NodeCollectionObject()
+    #        obj._set_nc(ncptr)
+    #        res.append(nest.NodeCollection(obj))
+    #    return res
 
     # This monostate represents missing NodeCollection status data (nodes on other ranks)
     # Translates to None for NEST 3.9 compatibility


### PR DESCRIPTION
Hi @JanVogelsang! It turned out that code which I had ported from the boost::any version to support semantic comparison of dictionaries was incorrect (but never used in a way that would have triggered an unwarranted exception). Fortunately, C++17 provides `operator==()` for variants, so all becomes much simpler. In the process I discovered that comparison for layers is buggy, but that is inherited from NEST 3.9. I will create an issue for that.

This PR now also reduces the variant to container types that are actually needed and removes other unused code.