### PR TITLE
Fix warnings about undefined template member when building with Clang

### DIFF
--- a/nestkernel/secondary_event.h
+++ b/nestkernel/secondary_event.h
@@ -144,8 +144,8 @@ template < typename DataType, typename Subclass >
 class DataSecondaryEvent : public SecondaryEvent
 {
 private:
-  static std::set< synindex > supported_syn_ids_;
-  static size_t coeff_length_;  // length of coeffarray
+  static inline std::set< synindex > supported_syn_ids_;
+  static inline size_t coeff_length_ = 0;  // length of coeffarray
 
   union CoeffarrayBegin
   {

--- a/nestkernel/secondary_event_impl.h
+++ b/nestkernel/secondary_event_impl.h
@@ -67,12 +67,6 @@ DataSecondaryEvent< DataType, Subclass >::get_coeffvalue( std::vector< unsigned 
   return elem;
 }
 
-template < typename DataType, typename Subclass >
-std::set< synindex > DataSecondaryEvent< DataType, Subclass >::supported_syn_ids_;
-
-template < typename DataType, typename Subclass >
-size_t DataSecondaryEvent< DataType, Subclass >::coeff_length_ = 0;
-
 /**
  * Event for slow inward current (SIC) connections between astrocytes and neurons.
  *


### PR DESCRIPTION
@JanVogelsang This PR fixes the warnings mentioned here: https://github.com/nest/nest-simulator/pull/3544#issuecomment-4241532113